### PR TITLE
Address-balance routing, GraphQL simulation & dependency cleanup

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,10 +11,8 @@
       "dependencies": {
         "@7kprotocol/sdk-ts": "^3.4.1",
         "@cetusprotocol/aggregator-sdk": "^1.5.5",
-        "@cetusprotocol/cetus-sui-clmm-sdk": "^5.4.0",
         "@pythnetwork/pyth-sui-js": "^2.2.0",
         "@types/bn.js": "^5.2.0",
-        "bech32": "^2.0.0",
         "decimal.js": "^10.5.0",
         "dotenv": "^17.2.2",
         "tslib": "^2.8.1"
@@ -624,59 +622,6 @@
       },
       "funding": {
         "url": "https://dotenvx.com"
-      }
-    },
-    "node_modules/@cetusprotocol/cetus-sui-clmm-sdk": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/@cetusprotocol/cetus-sui-clmm-sdk/-/cetus-sui-clmm-sdk-5.4.0.tgz",
-      "integrity": "sha512-k3SFPEPMFLV48/xIReh8C3nbKbCsRUd8N0Nio+zEHw3eZBFSHtTFxYTiDVnn3e/f5UBB7A6MEglYIDTFMwDfYQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@suchipi/femver": "^1.0.0",
-        "@syntsugar/cc-graph": "^0.1.1",
-        "@types/bn.js": "^5.1.1",
-        "axios": "^1.4.0",
-        "bn.js": "^5.2.1",
-        "cors": "^2.8.5",
-        "decimal.js": "^10.4.1",
-        "dotenv": "^16.4.7",
-        "isomorphic-fetch": "^3.0.0",
-        "js-base64": "^3.7.4",
-        "js-sha3": "^0.8.0",
-        "superstruct": "^1.0.3",
-        "tiny-invariant": "^1.1.0",
-        "tweetnacl": "^1.0.3",
-        "uuid": "^9.0.0"
-      },
-      "peerDependencies": {
-        "@mysten/bcs": ">=0.8.1",
-        "@mysten/sui": ">=1.1.2"
-      }
-    },
-    "node_modules/@cetusprotocol/cetus-sui-clmm-sdk/node_modules/dotenv": {
-      "version": "16.6.1",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
-      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://dotenvx.com"
-      }
-    },
-    "node_modules/@cetusprotocol/cetus-sui-clmm-sdk/node_modules/uuid": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
-      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/@cspotcode/source-map-support": {
@@ -1971,16 +1916,8 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@suchipi/femver/-/femver-1.0.0.tgz",
       "integrity": "sha512-bprE8+K5V+DPX7q2e2K57ImqNBdfGHDIWaGI5xHxZoxbKOuQZn4wzPiUxOAHnsUr3w3xHrWXwN7gnG/iIuEMIg==",
-      "license": "MIT"
-    },
-    "node_modules/@syntsugar/cc-graph": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/@syntsugar/cc-graph/-/cc-graph-0.1.1.tgz",
-      "integrity": "sha512-u5ne/gnGokhYGRrLs4IfQPWcNnxwHTO2KaqyJ6t6xupOLTyBuqAIeMpblDK8SGPBcXcWgePKZcirKJmY5cgHmQ==",
-      "dependencies": {
-        "ss-queue": "1.0.x",
-        "ss-stack": "1.0.x"
-      }
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/@tsconfig/node10": {
       "version": "1.0.12",
@@ -2889,6 +2826,7 @@
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
       "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "debug": "4"
       },
@@ -3151,7 +3089,8 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/available-typed-arrays": {
       "version": "1.0.7",
@@ -3174,6 +3113,7 @@
       "resolved": "https://registry.npmjs.org/axios/-/axios-1.17.0.tgz",
       "integrity": "sha512-J8SwNxprqqpbfenehxWYXE7CW+wM1BB4w3+N+g+/Wx40xM4rsLrfPmHHxSWIxJLYDgSY/HqlFPIYb2/S3rxafw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "follow-redirects": "^1.16.0",
         "form-data": "^4.0.5",
@@ -3357,7 +3297,8 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/bech32/-/bech32-2.0.0.tgz",
       "integrity": "sha512-LcknSilhIGatDAsY1ak2I8VtGaHNhgMSYVxFrGLXv+xLHytaKZKcaUJJUE7qmBr7h33o5YQwP55pMI0xmkpJwg==",
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/bignumber.js": {
       "version": "9.3.1",
@@ -3393,7 +3334,8 @@
       "version": "5.2.3",
       "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.3.tgz",
       "integrity": "sha512-EAcmnPkxpntVL+DS7bO1zhcZNvCkxqtkd0ZY53h06GNQ3DEkkGZ/gKgmDv6DdZQGj9BgfSPKtJJ7Dp1GPP8f7w==",
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/brace-expansion": {
       "version": "1.1.15",
@@ -3775,6 +3717,7 @@
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "delayed-stream": "~1.0.0"
       },
@@ -3805,23 +3748,6 @@
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/cors": {
-      "version": "2.8.6",
-      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
-      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
-      "license": "MIT",
-      "dependencies": {
-        "object-assign": "^4",
-        "vary": "^1"
-      },
-      "engines": {
-        "node": ">= 0.10"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
     },
     "node_modules/create-require": {
       "version": "1.1.1",
@@ -4491,6 +4417,7 @@
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.4.0"
       }
@@ -5276,6 +5203,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=4.0"
       },
@@ -5323,6 +5251,7 @@
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
       "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
@@ -5793,6 +5722,7 @@
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
       "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "agent-base": "6",
         "debug": "4"
@@ -6380,36 +6310,6 @@
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/isomorphic-fetch": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-3.0.0.tgz",
-      "integrity": "sha512-qvUtwJ3j6qwsF3jLxkZ72qCgjMysPzDfeV240JHiGZsANBYd+EEuu35v7dfrJ9Up0Ak07D7GGSkGhCHTqg/5wA==",
-      "license": "MIT",
-      "dependencies": {
-        "node-fetch": "^2.6.1",
-        "whatwg-fetch": "^3.4.1"
-      }
-    },
-    "node_modules/isomorphic-fetch/node_modules/node-fetch": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
-      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
-      "license": "MIT",
-      "dependencies": {
-        "whatwg-url": "^5.0.0"
-      },
-      "engines": {
-        "node": "4.x || >=6.0.0"
-      },
-      "peerDependencies": {
-        "encoding": "^0.1.0"
-      },
-      "peerDependenciesMeta": {
-        "encoding": {
-          "optional": true
-        }
-      }
     },
     "node_modules/istanbul-lib-coverage": {
       "version": "3.2.2",
@@ -7122,18 +7022,6 @@
         "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
-    "node_modules/js-base64": {
-      "version": "3.7.8",
-      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-3.7.8.tgz",
-      "integrity": "sha512-hNngCeKxIUQiEUN3GPJOkz4wF/YvdUdbNL9hsBcMQTkKzboD7T/q3OYOuuPZLUE6dBxSGpwhk5mwuDud7JVAow==",
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/js-sha3": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.8.0.tgz",
-      "integrity": "sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q==",
-      "license": "MIT"
-    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -7473,6 +7361,7 @@
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
       "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -7482,6 +7371,7 @@
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
       "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "mime-db": "1.52.0"
       },
@@ -7682,6 +7572,7 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -8207,6 +8098,7 @@
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
       "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -8667,38 +8559,6 @@
       "dev": true,
       "license": "BSD-3-Clause"
     },
-    "node_modules/ss-comparator": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/ss-comparator/-/ss-comparator-1.0.1.tgz",
-      "integrity": "sha512-zcZ/OhyVPx3AoOYxOJ7BmGM4USzlULFuPGTeMBwf6rf2RhS/0XISyOOYQu83U7OHl62AiEKlYv+sqFccP8L0Cg==",
-      "dependencies": {
-        "ss-linked-list": "^1.1.2"
-      }
-    },
-    "node_modules/ss-linked-list": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/ss-linked-list/-/ss-linked-list-1.1.5.tgz",
-      "integrity": "sha512-l/mMqU70q01cBJLL8Mu2FWUGKlAqiYrI2F68XMkNhyOsVx+Mh9gkgCMaZMyUkXCadQwx68isMHb8S4h88lHE2Q==",
-      "dependencies": {
-        "ss-comparator": "^1.0.0"
-      }
-    },
-    "node_modules/ss-queue": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/ss-queue/-/ss-queue-1.0.5.tgz",
-      "integrity": "sha512-1eyYJr00ZYRIbkMSBBSUrS2YAvVbjFCZ+CZZqNBw5Q7SQrOo9o3MjMhlEzPUsODhxjqPBtrqPzApuulCpjY3CQ==",
-      "dependencies": {
-        "ss-linked-list": "^1.1.1"
-      }
-    },
-    "node_modules/ss-stack": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/ss-stack/-/ss-stack-1.0.8.tgz",
-      "integrity": "sha512-bELljop9qaG6V1ZMC65IfHQOmkHk8RhMnnvJuezlMVcItILf8431EbLJ6dzwwP9w+mVxngGiUx8042wN9v6fLA==",
-      "dependencies": {
-        "ss-linked-list": "^1.1.2"
-      }
-    },
     "node_modules/stack-utils": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.6.tgz",
@@ -9013,6 +8873,7 @@
       "resolved": "https://registry.npmjs.org/superstruct/-/superstruct-1.0.4.tgz",
       "integrity": "sha512-7JpaAoX2NGyoFlI9NBh66BQXGONc+uE+MRS5i2iOBKuS4e+ccgMDjATgZldkah+33DakBxDHiss9kvUcGAO8UQ==",
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">=14.0.0"
       }
@@ -9100,7 +8961,8 @@
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
       "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/tinyglobby": {
       "version": "0.2.17",
@@ -9130,7 +8992,8 @@
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/ts-api-utils": {
       "version": "2.5.0",
@@ -9278,7 +9141,8 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.3.tgz",
       "integrity": "sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw==",
-      "license": "Unlicense"
+      "license": "Unlicense",
+      "optional": true
     },
     "node_modules/type-check": {
       "version": "0.4.0",
@@ -9668,15 +9532,6 @@
         }
       }
     },
-    "node_modules/vary": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
-      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
     "node_modules/walker": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/walker/-/walker-1.0.8.tgz",
@@ -9700,19 +9555,15 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
       "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
-      "license": "BSD-2-Clause"
-    },
-    "node_modules/whatwg-fetch": {
-      "version": "3.6.20",
-      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.6.20.tgz",
-      "integrity": "sha512-EqhiFU6daOA8kpjOWTL0olhVOF3i7OrFzSYiGsEMB8GcXS+RrzauAERX65xMeNWVqxA6HXH2m69Z9LaKKdisfg==",
-      "license": "MIT"
+      "license": "BSD-2-Clause",
+      "optional": true
     },
     "node_modules/whatwg-url": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
       "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "tr46": "~0.0.3",
         "webidl-conversions": "^3.0.0"

--- a/package.json
+++ b/package.json
@@ -35,10 +35,8 @@
   "dependencies": {
     "@7kprotocol/sdk-ts": "^3.4.1",
     "@cetusprotocol/aggregator-sdk": "^1.5.5",
-    "@cetusprotocol/cetus-sui-clmm-sdk": "^5.4.0",
     "@pythnetwork/pyth-sui-js": "^2.2.0",
     "@types/bn.js": "^5.2.0",
-    "bech32": "^2.0.0",
     "decimal.js": "^10.5.0",
     "dotenv": "^17.2.2",
     "tslib": "^2.8.1"

--- a/src/core/client.ts
+++ b/src/core/client.ts
@@ -653,7 +653,7 @@ export class AlphalendClient {
       coin = await this.handlePromise(tx, promise, params.coinType);
     }
     if (coin) {
-      tx.transferObjects([coin], params.address);
+      this.sendCoinToAddressBalance(tx, params.coinType, params.address, coin);
     }
 
     return tx;
@@ -775,7 +775,12 @@ export class AlphalendClient {
       coin,
     );
     if (withdrawCoin) {
-      tx.transferObjects([withdrawCoin], params.address);
+      this.sendCoinToAddressBalance(
+        tx,
+        params.outputCoinType,
+        params.address,
+        withdrawCoin,
+      );
     }
 
     return tx;
@@ -851,8 +856,13 @@ export class AlphalendClient {
       ],
     });
 
-    // Transfer remaining coin from repayment back to user
-    tx.transferObjects([remainingCoin], params.address);
+    // Credit remaining coin from repayment back to the user's address balance
+    this.sendCoinToAddressBalance(
+      tx,
+      params.swapToCoinType,
+      params.address,
+      remainingCoin,
+    );
 
     return tx;
   }
@@ -913,7 +923,7 @@ export class AlphalendClient {
         ],
       });
     }
-    tx.transferObjects([coin], params.address);
+    this.sendCoinToAddressBalance(tx, params.coinType, params.address, coin);
 
     return tx;
   }
@@ -952,7 +962,12 @@ export class AlphalendClient {
         tx.object(this.constants.SUI_CLOCK_OBJECT_ID), // Clock object
       ],
     });
-    tx.transferObjects([repayCoin], params.address);
+    this.sendCoinToAddressBalance(
+      tx,
+      params.coinType,
+      params.address,
+      repayCoin,
+    );
 
     return tx;
   }
@@ -1029,10 +1044,20 @@ export class AlphalendClient {
             }
           } else {
             if (coin2) {
-              tx.transferObjects([coin2], params.address);
+              this.sendCoinToAddressBalance(
+                tx,
+                coinType,
+                params.address,
+                coin2,
+              );
             }
             if (coin1) {
-              tx.transferObjects([coin1], params.address);
+              this.sendCoinToAddressBalance(
+                tx,
+                coinType,
+                params.address,
+                coin1,
+              );
             }
           }
         } else if (coin1) {
@@ -1042,7 +1067,7 @@ export class AlphalendClient {
           ) {
             alphaCoin = this.mergeCoins(tx, alphaCoin, [coin1]);
           } else {
-            tx.transferObjects([coin1], params.address);
+            this.sendCoinToAddressBalance(tx, coinType, params.address, coin1);
           }
         }
       }
@@ -1263,10 +1288,11 @@ export class AlphalendClient {
       }
     }
 
-    // Handle coins that should be claimed directly to wallet
+    // Handle coins that should be claimed directly to the user's address balance
     if (coinsToClaimDirectly.size > 0) {
-      const coinsToTransfer = Array.from(coinsToClaimDirectly.values());
-      tx.transferObjects(coinsToTransfer, params.address);
+      for (const [coinType, coin] of coinsToClaimDirectly.entries()) {
+        this.sendCoinToAddressBalance(tx, coinType, params.address, coin);
+      }
     }
 
     // If no target coin, all rewards were either too small or claimed directly
@@ -1281,7 +1307,12 @@ export class AlphalendClient {
     }
 
     if (params.transferTargetCoin) {
-      tx.transferObjects([targetCoin], params.address);
+      this.sendCoinToAddressBalance(
+        tx,
+        params.targetCoinType,
+        params.address,
+        targetCoin,
+      );
       return tx;
     }
 
@@ -1300,7 +1331,12 @@ export class AlphalendClient {
       });
 
       // todo - check if remainingCoin is zero and destroy it if it is
-      tx.transferObjects([remainingCoin], params.address);
+      this.sendCoinToAddressBalance(
+        tx,
+        params.targetCoinType,
+        params.address,
+        remainingCoin,
+      );
     } else {
       // Supply the remaining reward coin to the target market
       tx.moveCall({
@@ -1408,8 +1444,7 @@ export class AlphalendClient {
           ],
         });
       } else {
-        // todo - check if remainingCoin is zero and destroy it if it is
-        tx.transferObjects([coin], params.address);
+        this.sendCoinToAddressBalance(tx, coinType, params.address, coin);
       }
     };
 
@@ -1438,7 +1473,12 @@ export class AlphalendClient {
         });
 
         // todo - check if remainingCoin is zero and destroy it if it is
-        tx.transferObjects([remainingCoin], params.address);
+        this.sendCoinToAddressBalance(
+          tx,
+          coinType,
+          params.address,
+          remainingCoin,
+        );
       } else {
         // Not borrowed - supply or transfer
         handleCoin(mergedCoin, coinType, params.supplyMarkets?.get(coinType));
@@ -1737,6 +1777,25 @@ export class AlphalendClient {
     amount: bigint,
   ): TransactionObjectArgument {
     return this.blockchain.getCoinObject(tx, type, address, amount);
+  }
+
+  /**
+   * Credits a coin to `address`'s address balance (the accumulator) instead of
+   * sending it as a standalone coin object. Used to return withdrawn/borrowed
+   * coins and leftovers back to the user.
+   *
+   * @param tx Transaction to which the move call will be added
+   * @param type Fully qualified coin type being returned
+   * @param address Recipient whose address balance is credited
+   * @param coin The coin to credit (consumed by the call)
+   */
+  sendCoinToAddressBalance(
+    tx: Transaction,
+    type: string,
+    address: string,
+    coin: TransactionObjectArgument | string,
+  ): void {
+    this.blockchain.sendCoinToAddressBalance(tx, type, address, coin);
   }
 
   private async handlePromise(

--- a/src/core/flashRepay.ts
+++ b/src/core/flashRepay.ts
@@ -342,8 +342,13 @@ export async function buildFlashRepayTransaction(
     ],
   });
 
-  // Step 10b: Transfer any leftover (after second repay) to user.
-  tx.transferObjects([leftoverCoin], params.address);
+  // Step 10b: Credit any leftover (after second repay) to the user's address balance.
+  client.sendCoinToAddressBalance(
+    tx,
+    params.repayCoinType,
+    params.address,
+    leftoverCoin,
+  );
 
   return tx;
 }

--- a/src/models/blockchain.ts
+++ b/src/models/blockchain.ts
@@ -1,15 +1,11 @@
 /**
  * Blockchain interface wrapper for Sui network operations using the SuiGraphQLClient.
  *
- * All reads go through GraphQL. The public API exposes no JSON-RPC client.
- * Transaction building (BCS serialization for simulation) still requires a
- * `SuiClient` internally because `Transaction.build()` needs chain-backed
- * resolution of input object versions (e.g. the sender's gas coin). We
- * construct that client privately from the default JSON-RPC endpoint; it is
- * never exposed to callers.
+ * All operations go through GraphQL, including transaction simulation via
+ * `gqlClient.core.simulateTransaction`, which builds the transaction, resolves
+ * gas, and simulates server-side. No JSON-RPC or gRPC client is used.
  */
 
-import { SuiJsonRpcClient, getJsonRpcFullnodeUrl } from "@mysten/sui/jsonRpc";
 import { SuiGraphQLClient } from "@mysten/sui/graphql";
 import { graphql } from "@mysten/sui/graphql/schema";
 import {
@@ -58,13 +54,6 @@ export class Blockchain {
   gqlClient: SuiGraphQLClient;
   constants: Constants;
 
-  /**
-   * Internal-only SuiClient used solely for `Transaction.build()` input
-   * resolution (gas coin lookup etc.) during simulation. Never returned to
-   * callers; all public reads still go through `gqlClient`.
-   */
-  private txBuildClient: SuiJsonRpcClient;
-
   private initialSharedVersionCache: Map<string, string> = new Map();
 
   constructor(network: Network, graphqlUrl?: string) {
@@ -72,10 +61,6 @@ export class Blockchain {
     this.constants = getConstants(network);
     this.gqlClient = new SuiGraphQLClient({
       url: graphqlUrl ?? GRAPHQL_URL[network],
-      network,
-    });
-    this.txBuildClient = new SuiJsonRpcClient({
-      url: getJsonRpcFullnodeUrl(network),
       network,
     });
   }
@@ -525,43 +510,21 @@ export class Blockchain {
   // --------------------------------------------------------------------------
 
   /**
-   * Simulate a transaction via GraphQL. The transaction is built with no
-   * client (client-less BCS serialization) — this works for all transactions
-   * constructed by this SDK because inputs are already fully-resolved object
-   * references.
+   * Simulate a transaction via the GraphQL client's core API, which builds the
+   * transaction, resolves gas, and simulates server-side. Returns the parsed
+   * transaction effects (or undefined if effects are unavailable).
    */
   async simulateTransaction(tx: Transaction, sender: string) {
     tx.setSenderIfNotSet(sender);
-    const txBytes = await tx.build({ client: this.txBuildClient });
-    const txBase64 = toBase64(txBytes);
-
-    const query = graphql(`
-      query simulate($tx: JSON!) {
-        simulateTransaction(
-          transaction: $tx
-          checksEnabled: true
-          doGasSelection: true
-        ) {
-          effects {
-            status
-            gasEffects {
-              gasSummary {
-                computationCost
-                storageCost
-                storageRebate
-                nonRefundableStorageFee
-              }
-            }
-          }
-        }
-      }
-    `);
-
-    const result = await this.gqlClient.query({
-      query,
-      variables: { tx: { bcs: { value: txBase64 } } },
+    const result = await this.gqlClient.core.simulateTransaction({
+      transaction: tx,
+      include: { effects: true },
     });
-    return result.data?.simulateTransaction ?? undefined;
+    const txData =
+      result.$kind === "Transaction"
+        ? result.Transaction
+        : result.FailedTransaction;
+    return txData?.effects ?? undefined;
   }
 
   /** Estimate gas budget by simulating the transaction. */
@@ -571,17 +534,17 @@ export class Blockchain {
   ): Promise<number | undefined> {
     const fallbackBudget = 500_000_000;
     try {
-      const simResult = await this.simulateTransaction(tx, sender);
-      const gasSummary = simResult?.effects?.gasEffects?.gasSummary;
-      if (!gasSummary) {
+      const effects = await this.simulateTransaction(tx, sender);
+      const gasUsed = effects?.gasUsed;
+      if (!gasUsed) {
         console.warn(
           "Simulation returned no gas summary; using fallback gas budget",
         );
         return fallbackBudget;
       }
       const estimatedBudget =
-        Number(gasSummary.computationCost) +
-        Number(gasSummary.nonRefundableStorageFee) +
+        Number(gasUsed.computationCost) +
+        Number(gasUsed.nonRefundableStorageFee) +
         fallbackBudget;
       if (!Number.isFinite(estimatedBudget) || estimatedBudget <= 0) {
         console.warn("Simulation returned invalid gas summary; using fallback");

--- a/src/models/blockchain.ts
+++ b/src/models/blockchain.ts
@@ -12,7 +12,10 @@
 import { SuiJsonRpcClient, getJsonRpcFullnodeUrl } from "@mysten/sui/jsonRpc";
 import { SuiGraphQLClient } from "@mysten/sui/graphql";
 import { graphql } from "@mysten/sui/graphql/schema";
-import { Transaction } from "@mysten/sui/transactions";
+import {
+  Transaction,
+  TransactionObjectArgument,
+} from "@mysten/sui/transactions";
 import { bcs } from "@mysten/sui/bcs";
 import { toBase64 } from "@mysten/sui/utils";
 
@@ -268,6 +271,25 @@ export class Blockchain {
   ) {
     tx.setSenderIfNotSet(address);
     return tx.coin({ type: coinType, balance: amount });
+  }
+
+  /**
+   * Credit a `Coin<coinType>` to `address`'s address balance (the accumulator)
+   */
+  sendCoinToAddressBalance(
+    tx: Transaction,
+    coinType: string,
+    address: string,
+    coin: TransactionObjectArgument | string,
+  ) {
+    tx.moveCall({
+      target: "0x2::coin::send_funds",
+      typeArguments: [coinType],
+      arguments: [
+        typeof coin === "string" ? tx.object(coin) : coin,
+        tx.pure.address(address),
+      ],
+    });
   }
 
   // --------------------------------------------------------------------------


### PR DESCRIPTION
## Route coins to address-balance
- Add `Blockchain.sendCoinToAddressBalance` — credits a coin to a recipient's address balance via `0x2::coin::send_funds`.
- Route output/leftover coins to the address balance in `client.ts` and `flashRepay.ts`.

## Migrate transaction simulation to GraphQL
- `simulateTransaction`: replace `tx.build()` + hand-written query with `gqlClient.core.simulateTransaction` (server-side build + gas resolution).
- Remove the internal JSON-RPC `txBuildClient`; `blockchain.ts` is now JSON-RPC-free.

## Dependency cleanup
- Remove `@cetusprotocol/cetus-sui-clmm-sdk` and `bech32` — both unused (no imports anywhere; not peer deps of the aggregator SDK).