### PR TITLE
feat(oracle): add Pyth Lazer price path (verify-in-PTB), flag-gated

### DIFF
--- a/__tests__/lazer.e2e.test.ts
+++ b/__tests__/lazer.e2e.test.ts
@@ -1,0 +1,230 @@
+/**
+ * Pyth Lazer mock-signer e2e (testnet, gasless `devInspect`) — the full push path WITHOUT a Pyth token.
+ *
+ * What it proves: the SDK's {@link appendLazerUpdate} builds a PTB that the REAL on-chain Lazer verifier
+ * accepts and that `alphafi_oracle::ingest_lazer_update` writes the price end-to-end. We can't fetch a
+ * real Pyth-signed payload here (the access token lives only in the backend proxy), so we sign the Lazer
+ * `leEcdsa` update with a key WE control — the exact wire format Pyth uses, only the signer differs — and
+ * register it on a self-published harness verifier whose `state::set_trusted_signer` is permissionless.
+ *
+ * Why it's keyless and deterministic: verify -> ingest -> read all run in ONE `devInspect`. devInspect
+ * executes the commands in order in-memory and never commits, so the `ingest_lazer_update` mutation is
+ * visible to the `get_price` read in the same call. No funded key, no gas, and the read-back reflects the
+ * value WE just signed (a distinctive $1337, distinct from any previously-stored testnet price) — so a
+ * pass means this run's verify+ingest actually wrote, not that an old value happened to be there.
+ *
+ * Gated behind `LAZER_E2E=1` (needs testnet network + the harness/oracle objects below), so the default
+ * `npm test` (CI) skips it. Run it on demand with:
+ *   LAZER_E2E=1 npm test -- lazer.e2e
+ *
+ * @noble/curves + @noble/hashes are provided transitively by @mysten/sui (same as the contracts-repo
+ * signer); this test imports them directly rather than adding a dependency.
+ */
+import { secp256k1 } from "@noble/curves/secp256k1.js";
+import { keccak_256 } from "@noble/hashes/sha3.js";
+import { Transaction } from "@mysten/sui/transactions";
+import { SuiJsonRpcClient } from "@mysten/sui/jsonRpc";
+import { appendLazerUpdate } from "../src/utils/lazer.js";
+
+// --- Testnet mock-signer harness deployment (see oracle-migration/lazer-migration/testnet-e2e) ---------
+// alphafi_oracle refactored to the ingest_lazer_update consumer; SUI is registered to Lazer feed_id 2.
+const ORACLE_PKG =
+  "0xa22cc6fa2ed207568b620e5adcc6b28999f4ad50110f342fe6f54a47d4705ef0";
+const ORACLE_OBJ =
+  "0xa577a610c3f604865b35ab65c99e3a9bc8186cf6899cfd08158b90f651c85bea";
+// Self-published `pyth_lazer` (full v2 source) whose set_trusted_signer is permissionless, plus its State.
+const HARNESS_PKG =
+  "0xf9686303df959b4b6a000fcac0befe0cc2cee24f2c2ec02dae914b3c525a5639";
+const HARNESS_STATE =
+  "0x470a1b15fae80369812c0f96f70788321f6f822ff8b8f35884743c175919fc39";
+const CLOCK = "0x6";
+const SUI_T = "0x2::sui::SUI";
+// devInspect needs only a syntactically-valid sender (no funds / no signing).
+const SENDER = `0x${"11".repeat(32)}`;
+
+// Signed feed values. Distinctive $1337 (not the $2500 a prior testnet run stored) so the read-back can
+// ONLY match if this devInspect's verify+ingest wrote it. ema == spot so the circuit breaker diff is 0;
+// conf of $1 is ~0.07% of price, well inside the 10% band the oracle enforces.
+const FEED_ID = 2;
+const EXPO = -8;
+const PRICE_M = 133_700_000_000n; // 1337.00000000 (x1e8, expo -8)
+const EMA_M = 133_700_000_000n;
+const CONF_M = 100_000_000n; //    1.00
+const ECONF_M = 100_000_000n; //   1.00
+const SCALE = 10n ** 18n; // alphafi_stdlib::math::Number value scale
+const EXPECTED_USD = 1337;
+
+// Fixed mock secp256k1 key (testnet-only, reproducible). Its compressed pubkey is the trusted signer.
+const MOCK_PRIV = Uint8Array.from(Buffer.from("01".repeat(32), "hex"));
+const MOCK_PUB = secp256k1.getPublicKey(MOCK_PRIV, true);
+
+const u8 = (n: number) => Uint8Array.from([n & 0xff]);
+const u16le = (n: number) => Uint8Array.from([n & 0xff, (n >> 8) & 0xff]);
+const u32le = (n: number) => {
+  const b = new Uint8Array(4);
+  new DataView(b.buffer).setUint32(0, n >>> 0, true);
+  return b;
+};
+const u64le = (n: bigint) => {
+  const b = new Uint8Array(8);
+  new DataView(b.buffer).setBigUint64(0, n, true);
+  return b;
+};
+const cat = (...xs: Uint8Array[]) =>
+  Uint8Array.from(xs.flatMap((x) => Array.from(x)));
+
+// secp256k1 recoverable signature over a 32-byte digest -> r||s||recid (65 bytes), Pyth leEcdsa layout.
+function signRecoverable(digest: Uint8Array): Uint8Array {
+  const sig = secp256k1.sign(digest, MOCK_PRIV, {
+    format: "recovered",
+    prehash: false,
+  }) as unknown;
+  if (sig instanceof Uint8Array) {
+    // @noble v2 "recovered" format prepends the recid; reorder to r||s||recid.
+    return cat(sig.slice(1), u8(sig[0]));
+  }
+  const s = sig as { toCompactRawBytes(): Uint8Array; recovery: number };
+  return cat(s.toCompactRawBytes(), u8(s.recovery));
+}
+
+// Build a signed Lazer leEcdsa update: one feed with the full property set ingest_lazer_update requires
+// (price=0, exponent=4, confidence=5, ema_price=10, ema_confidence=11). On-chain the signature is checked
+// as secp256k1_ecrecover(sig, payload, keccak256), so we sign keccak256(payload).
+function buildSignedUpdate(tsMicros: bigint): Uint8Array {
+  const UPDATE_MAGIC = 1296547300; // 0x4D47BDE4
+  const PAYLOAD_MAGIC = 2479346549; // 0x93C7D375
+  const expoU16 = EXPO < 0 ? 0x10000 + EXPO : EXPO; // two's-complement -> i16::from_u16
+  const feed = cat(
+    u32le(FEED_ID),
+    u8(5), // properties_count
+    u8(0),
+    u64le(PRICE_M),
+    u8(4),
+    u16le(expoU16),
+    u8(5),
+    u64le(CONF_M),
+    u8(10),
+    u64le(EMA_M),
+    u8(11),
+    u64le(ECONF_M),
+  );
+  const payload = cat(
+    u32le(PAYLOAD_MAGIC),
+    u64le(tsMicros),
+    u8(4), // channel 4 = fixed_rate@1000ms
+    u8(1), // feed_count
+    feed,
+  );
+  const digest = keccak_256(payload);
+  return cat(u32le(UPDATE_MAGIC), signRecoverable(digest), u16le(payload.length), payload);
+}
+
+// Decode a Move `Number { value: u256 }` (BCS = bare 32-byte LE u256) from a devInspect return value.
+function decodeNumberValue(bytes: Uint8Array): bigint {
+  let v = 0n;
+  for (let i = bytes.length - 1; i >= 0; i--) v = (v << 8n) | BigInt(bytes[i]);
+  return v;
+}
+
+const RUN = process.env.LAZER_E2E === "1";
+
+(RUN ? describe : describe.skip)(
+  "Lazer mock-signer e2e (testnet devInspect, keyless)",
+  () => {
+    it("appendLazerUpdate: verify -> ingest_lazer_update -> read writes the signed price", async () => {
+      const client = new SuiJsonRpcClient({
+        url: "https://fullnode.testnet.sui.io",
+        network: "testnet",
+      });
+
+      // appendLazerUpdate references the Oracle as an explicit mutable SharedObjectRef (mirroring the Pyth
+      // writer), so it needs the Oracle's initial shared version — fetch it live.
+      const oracleObj = await client.getObject({
+        id: ORACLE_OBJ,
+        options: { showOwner: true },
+      });
+      const owner = oracleObj.data?.owner as
+        | { Shared?: { initial_shared_version: number | string } }
+        | undefined;
+      const initialSharedVersion = owner?.Shared?.initial_shared_version;
+      if (!initialSharedVersion) {
+        throw new Error(
+          `Oracle ${ORACLE_OBJ} not found or not shared on testnet (deployment pruned?)`,
+        );
+      }
+
+      // Stamp the payload with the on-chain clock time so the freshness gate (max_age) and the monotonic
+      // last_updated guard always pass — the read-back then reflects THIS run's write.
+      const clockObj = await client.getObject({
+        id: CLOCK,
+        options: { showContent: true },
+      });
+      const clockContent = clockObj.data?.content as
+        | { fields?: { timestamp_ms?: string } }
+        | undefined;
+      const clockMs = BigInt(clockContent?.fields?.timestamp_ms ?? Date.now());
+      const update = buildSignedUpdate(clockMs * 1000n);
+
+      const tx = new Transaction();
+      tx.setSender(SENDER);
+      // Permissionless: (re)assert our mock signer as trusted (simulated inside the devInspect).
+      tx.moveCall({
+        target: `${HARNESS_PKG}::state::set_trusted_signer`,
+        arguments: [
+          tx.object(HARNESS_STATE),
+          tx.pure.vector("u8", Array.from(MOCK_PUB)),
+          tx.pure.u64(4102444800n), // expiry: year 2100
+        ],
+      });
+      // The SDK function under test: verify-in-PTB + oracle::ingest_lazer_update.
+      appendLazerUpdate(
+        tx,
+        HARNESS_PKG,
+        ORACLE_PKG,
+        ORACLE_OBJ,
+        String(initialSharedVersion),
+        HARNESS_STATE,
+        update,
+      );
+      // Read SUI's price back: type_name::get -> get_price_info -> get_price.
+      const tn = tx.moveCall({
+        target: "0x1::type_name::get",
+        typeArguments: [SUI_T],
+      });
+      const pi = tx.moveCall({
+        target: `${ORACLE_PKG}::oracle::get_price_info`,
+        arguments: [tx.object(ORACLE_OBJ), tn],
+      });
+      tx.moveCall({
+        target: `${ORACLE_PKG}::oracle::get_price`,
+        arguments: [pi],
+      });
+
+      const sim = await client.devInspectTransactionBlock({
+        sender: SENDER,
+        transactionBlock: tx,
+      });
+
+      if (sim.effects?.status?.status !== "success") {
+        throw new Error(
+          `devInspect failed: ${JSON.stringify(sim.effects?.status)}`,
+        );
+      }
+
+      const results = sim.results ?? [];
+      const rv = results[results.length - 1]?.returnValues?.[0];
+      expect(rv).toBeTruthy();
+      const value = decodeNumberValue(Uint8Array.from(rv![0] as number[]));
+      // eslint-disable-next-line no-console
+      console.log(
+        `[lazer e2e] devInspect=success  signed=$${EXPECTED_USD}  on-chain get_price=$${
+          Number(value) / 1e18
+        }  (Number.value=${value})`,
+      );
+
+      // price = mantissa * 10^expo * SCALE = 1337e8 * 1e-8 * 1e18 = 1337 * SCALE, exactly.
+      expect(value).toBe(BigInt(EXPECTED_USD) * SCALE);
+      expect(Number(value / SCALE)).toBe(EXPECTED_USD);
+    }, 60_000);
+  },
+);

--- a/__tests__/lazer.e2e.test.ts
+++ b/__tests__/lazer.e2e.test.ts
@@ -27,11 +27,12 @@ import { SuiJsonRpcClient } from "@mysten/sui/jsonRpc";
 import { appendLazerUpdate } from "../src/utils/lazer.js";
 
 // --- Testnet mock-signer harness deployment (see oracle-migration/lazer-migration/testnet-e2e) ---------
-// alphafi_oracle refactored to the ingest_lazer_update consumer; SUI is registered to Lazer feed_id 2.
+// Latest testnet alphafi_oracle refactored to the ingest_lazer_update consumer; SUI is registered to
+// Lazer feed_id 11.
 const ORACLE_PKG =
-  "0xa22cc6fa2ed207568b620e5adcc6b28999f4ad50110f342fe6f54a47d4705ef0";
+  "0xde8437ddf4fdfe2bb87ed5ba1b26c24773b75bb90656b4c5a5d4b793c5e22c2b";
 const ORACLE_OBJ =
-  "0xa577a610c3f604865b35ab65c99e3a9bc8186cf6899cfd08158b90f651c85bea";
+  "0x798196e3673aa7f3c36cfd7455511efcd11b982bd28d026a03e77643deb1b6a4";
 // Self-published `pyth_lazer` (full v2 source) whose set_trusted_signer is permissionless, plus its State.
 const HARNESS_PKG =
   "0xf9686303df959b4b6a000fcac0befe0cc2cee24f2c2ec02dae914b3c525a5639";
@@ -45,7 +46,7 @@ const SENDER = `0x${"11".repeat(32)}`;
 // Signed feed values. Distinctive $1337 (not the $2500 a prior testnet run stored) so the read-back can
 // ONLY match if this devInspect's verify+ingest wrote it. ema == spot so the circuit breaker diff is 0;
 // conf of $1 is ~0.07% of price, well inside the 10% band the oracle enforces.
-const FEED_ID = 2;
+const FEED_ID = 11;
 const EXPO = -8;
 const PRICE_M = 133_700_000_000n; // 1337.00000000 (x1e8, expo -8)
 const EMA_M = 133_700_000_000n;

--- a/__tests__/lazer.test.ts
+++ b/__tests__/lazer.test.ts
@@ -1,0 +1,362 @@
+/**
+ * Pyth Lazer SDK tests. Unit cases mock `global.fetch`; e2e cases use a local proxy server so the
+ * client fetches over HTTP and builds the real PTB command sequence deterministically.
+ */
+import { jest } from "@jest/globals";
+import { createServer, type Server } from "node:http";
+import type { AddressInfo } from "node:net";
+import { Transaction } from "@mysten/sui/transactions";
+import {
+  appendLazerUpdate,
+  fetchLazerUpdateBytes,
+} from "../src/utils/lazer.js";
+import {
+  appendOracleToLendingBridge,
+  updatePriceTransaction,
+} from "../src/utils/oracle.js";
+import { getConstants, type Network } from "../src/constants/index.js";
+import type { Constants } from "../src/constants/types.js";
+import { AlphalendClient } from "../src/index.js";
+
+// Client-side freshness ceiling passed in tests (mirrors the per-network LAZER_MAX_PROXY_AGE_MS constant).
+const MAX = 3000;
+
+const originalFetch = global.fetch;
+afterEach(() => {
+  global.fetch = originalFetch;
+  jest.restoreAllMocks();
+});
+
+// Install a typed `global.fetch` mock and return it for per-test configuration.
+function installFetch() {
+  const m = jest.fn<(input: string) => Promise<unknown>>();
+  global.fetch = m as unknown as typeof fetch;
+  return m;
+}
+const okBody = (hex: string, ageMs = 10) => ({
+  ok: true,
+  json: async () => ({ hex, ageMs }),
+});
+const errStatus = (status = 503) => ({
+  ok: false,
+  status,
+  statusText: "Service Unavailable",
+});
+
+async function closeServer(server: Server) {
+  await new Promise<void>((resolve, reject) => {
+    server.close((err) => (err ? reject(err) : resolve()));
+  });
+}
+
+async function withLazerProxy<T>(
+  body: { hex: string; ageMs: number },
+  run: (proxyUrl: string, requests: string[]) => Promise<T>,
+): Promise<T> {
+  const requests: string[] = [];
+  const server = createServer((req, res) => {
+    requests.push(req.url ?? "");
+    if (req.url === "/lazer/update") {
+      res.writeHead(200, { "content-type": "application/json" });
+      res.end(JSON.stringify(body));
+      return;
+    }
+    res.writeHead(404);
+    res.end();
+  });
+
+  await new Promise<void>((resolve) => {
+    server.listen(0, "127.0.0.1", resolve);
+  });
+
+  const { port } = server.address() as AddressInfo;
+  try {
+    return await run(`http://127.0.0.1:${port}`, requests);
+  } finally {
+    await closeServer(server);
+  }
+}
+
+function buildLazerClient(proxyUrl: string) {
+  const client = new AlphalendClient("testnet", undefined, {
+    coinMetadataMap: new Map(),
+  });
+  client.useLazer = true;
+  client.constants.LAZER_PROXY_URL = proxyUrl;
+  client.constants.LAZER_MAX_PROXY_AGE_MS = MAX;
+  jest
+    .spyOn(client.blockchain, "getInitialSharedVersion")
+    .mockResolvedValue("123");
+  return client;
+}
+
+function expectCompleteLazerRefresh(
+  tx: Transaction,
+  constants: Constants,
+  expectedBridgeCount: number,
+) {
+  const commands = tx.getData().commands;
+  const json = JSON.stringify(tx.getData());
+
+  expect(commands).toHaveLength(2 + expectedBridgeCount * 3);
+  expect(json).toContain(`"package":"${constants.LAZER_PACKAGE_ID}"`);
+  expect(json).toContain(
+    `"package":"${constants.ALPHAFI_LATEST_ORACLE_PACKAGE_ID}"`,
+  );
+  expect(json).toContain(
+    '"module":"pyth_lazer","function":"parse_and_verify_le_ecdsa_update_v2"',
+  );
+  expect(json).toContain('"module":"oracle","function":"ingest_lazer_update"');
+  expect(json.match(/"module":"type_name","function":"get"/g)).toHaveLength(
+    expectedBridgeCount,
+  );
+  expect(
+    json.match(/"module":"oracle","function":"get_price_info"/g),
+  ).toHaveLength(expectedBridgeCount);
+  expect(
+    json.match(/"module":"alpha_lending","function":"update_price"/g),
+  ).toHaveLength(expectedBridgeCount);
+  expect(json).not.toContain("update_price_from_pyth");
+}
+
+describe("Lazer constants", () => {
+  it("exposes complete Lazer config for every SDK network", () => {
+    for (const network of ["mainnet", "testnet", "devnet"] as Network[]) {
+      const constants = getConstants(network);
+      expect(constants.LAZER_PACKAGE_ID).toMatch(/^0x[0-9a-f]+$/i);
+      expect(constants.LAZER_STATE_ID).toMatch(/^0x[0-9a-f]+$/i);
+      expect(constants.LAZER_PROXY_URL).toMatch(/^https:\/\//);
+      expect(constants.LAZER_MAX_PROXY_AGE_MS).toBeGreaterThan(0);
+      expect(constants.LAZER_ENABLED).toBe(false);
+    }
+  });
+});
+
+describe("fetchLazerUpdateBytes", () => {
+  it("fetches, checks freshness, and decodes the hex payload", async () => {
+    const fetchMock = installFetch();
+    fetchMock.mockResolvedValue(okBody("000102", 42));
+    const bytes = await fetchLazerUpdateBytes("https://api.example/", MAX);
+    expect([...bytes]).toEqual([0, 1, 2]);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock).toHaveBeenCalledWith("https://api.example/lazer/update");
+  });
+
+  it("decodes a 0x-prefixed payload", async () => {
+    installFetch().mockResolvedValue(okBody("0x00ff", 10));
+    expect([
+      ...(await fetchLazerUpdateBytes("https://api.example", MAX)),
+    ]).toEqual([0, 255]);
+  });
+
+  it("normalizes trailing slashes in the proxy url", async () => {
+    const fetchMock = installFetch();
+    fetchMock.mockResolvedValue(okBody("00"));
+    await fetchLazerUpdateBytes("https://api.example///", MAX);
+    expect(fetchMock).toHaveBeenCalledWith("https://api.example/lazer/update");
+  });
+
+  it("rejects a stale proxy payload", async () => {
+    installFetch().mockResolvedValue(okBody("000102", 3001));
+    await expect(
+      fetchLazerUpdateBytes("https://api.example", MAX),
+    ).rejects.toThrow(/stale/i);
+  });
+
+  it("fails closed when the proxy omits ageMs", async () => {
+    installFetch().mockResolvedValue({
+      ok: true,
+      json: async () => ({ hex: "00" }),
+    });
+    await expect(
+      fetchLazerUpdateBytes("https://api.example", MAX),
+    ).rejects.toThrow(/ageMs/i);
+  });
+
+  it("retries a transient failure, then succeeds", async () => {
+    const fetchMock = installFetch();
+    fetchMock
+      .mockResolvedValueOnce(errStatus(503))
+      .mockResolvedValueOnce(okBody("aabb"));
+    expect([
+      ...(await fetchLazerUpdateBytes("https://api.example", MAX)),
+    ]).toEqual([0xaa, 0xbb]);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("fails closed after exhausting retries (never falls back to Pyth)", async () => {
+    const fetchMock = installFetch();
+    fetchMock.mockResolvedValue(errStatus(503));
+    await expect(
+      fetchLazerUpdateBytes("https://api.example", MAX),
+    ).rejects.toThrow();
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+  });
+
+  it("fails closed on a network-level error", async () => {
+    const fetchMock = installFetch();
+    fetchMock.mockRejectedValue(new Error("ECONNREFUSED"));
+    await expect(
+      fetchLazerUpdateBytes("https://api.example", MAX),
+    ).rejects.toThrow();
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+  });
+});
+
+describe("appendLazerUpdate", () => {
+  it("appends a PTB verify then oracle::ingest_lazer_update (verify-in-PTB)", () => {
+    const tx = new Transaction();
+    appendLazerUpdate(
+      tx,
+      "0x100", // lazer package id (exposes the verifier)
+      "0x101", // oracle package id
+      "0x102", // oracle object id
+      "1", // oracle initial shared version
+      "0x103", // lazer state id
+      new Uint8Array([1, 2, 3]),
+    );
+    expect(tx.getData().commands).toHaveLength(2);
+    const json = JSON.stringify(tx.getData());
+    expect(json).toContain("parse_and_verify_le_ecdsa_update_v2");
+    expect(json).toContain("ingest_lazer_update");
+    // The verifier call must NOT live inside our oracle anymore.
+    expect(json).not.toContain("update_price_from_lazer");
+  });
+});
+
+describe("appendOracleToLendingBridge", () => {
+  it("appends type_name::get + oracle::get_price_info + alpha_lending::update_price", () => {
+    const tx = new Transaction();
+    appendOracleToLendingBridge(tx, "0x2::sui::SUI", {
+      ALPHAFI_LATEST_ORACLE_PACKAGE_ID: "0x10",
+      ALPHAFI_ORACLE_OBJECT_ID: "0x11",
+      ALPHALEND_LATEST_PACKAGE_ID: "0x12",
+      LENDING_PROTOCOL_ID: "0x13",
+    } as unknown as Constants);
+    expect(tx.getData().commands).toHaveLength(3);
+    const json = JSON.stringify(tx.getData());
+    expect(json).toContain("get_price_info");
+    expect(json).toContain("update_price");
+  });
+});
+
+describe("price-refresh routing (useLazer)", () => {
+  it("updatePrices routes to the Lazer path when useLazer is set", async () => {
+    const client = new AlphalendClient("mainnet");
+    client.useLazer = true;
+    const spy = jest
+      .spyOn(client, "updatePricesLazer")
+      .mockImplementation(async () => {});
+    const tx = new Transaction();
+    await client.updatePrices(tx, ["0x2::sui::SUI"]);
+    expect(spy).toHaveBeenCalledWith(tx, ["0x2::sui::SUI"]);
+  });
+
+  it("updateAllPrices routes to the Lazer path when useLazer is set", async () => {
+    const client = new AlphalendClient("mainnet");
+    client.useLazer = true;
+    const spy = jest
+      .spyOn(client, "updatePricesLazer")
+      .mockImplementation(async () => {});
+    const tx = new Transaction();
+    await client.updateAllPrices(tx, ["0x2::sui::SUI"]);
+    expect(spy).toHaveBeenCalledWith(tx, ["0x2::sui::SUI"]);
+  });
+});
+
+describe("Lazer price refresh e2e", () => {
+  it("updatePrices fetches from the proxy and builds verify, ingest, and lending bridge calls", async () => {
+    await withLazerProxy(
+      { hex: "0x010203", ageMs: 1 },
+      async (proxyUrl, requests) => {
+        const client = buildLazerClient(proxyUrl);
+        const tx = new Transaction();
+
+        await client.updatePrices(tx, [
+          client.constants.SUI_COIN_TYPE,
+          client.constants.SUI_COIN_TYPE,
+          client.constants.USDC_COIN_TYPE,
+        ]);
+
+        expect(requests).toEqual(["/lazer/update"]);
+        expect(client.blockchain.getInitialSharedVersion).toHaveBeenCalledWith(
+          client.constants.ALPHAFI_ORACLE_OBJECT_ID,
+        );
+        expectCompleteLazerRefresh(tx, client.constants, 2);
+      },
+    );
+  });
+
+  it("updateAllPrices uses the same complete Lazer refresh path", async () => {
+    await withLazerProxy(
+      { hex: "0x0a0b0c", ageMs: 1 },
+      async (proxyUrl, requests) => {
+        const client = buildLazerClient(proxyUrl);
+        const tx = new Transaction();
+
+        await client.updateAllPrices(tx, [client.constants.SUI_COIN_TYPE]);
+
+        expect(requests).toEqual(["/lazer/update"]);
+        expectCompleteLazerRefresh(tx, client.constants, 1);
+      },
+    );
+  });
+});
+
+// The Pyth refresh path must keep building correctly while Lazer is added alongside it (the migration
+// adds Lazer, it does not delete Pyth) — and must never smuggle in a Lazer verify/ingest call.
+describe("Pyth path intact (updatePriceTransaction)", () => {
+  it("builds update_price_from_pyth + the lending bridge, with no Lazer calls", () => {
+    const tx = new Transaction();
+    updatePriceTransaction(
+      tx,
+      { priceInfoObject: "0x999", coinType: "0x2::sui::SUI" },
+      {
+        ALPHAFI_LATEST_ORACLE_PACKAGE_ID: "0x10",
+        ALPHAFI_ORACLE_OBJECT_ID: "0x11",
+        ALPHALEND_LATEST_PACKAGE_ID: "0x12",
+        LENDING_PROTOCOL_ID: "0x13",
+        SUI_CLOCK_OBJECT_ID: "0x6",
+      } as unknown as Constants,
+      "7", // oracle initial shared version
+    );
+    // update_price_from_pyth + type_name::get + get_price_info + alpha_lending::update_price
+    expect(tx.getData().commands).toHaveLength(4);
+    const json = JSON.stringify(tx.getData());
+    expect(json).toContain("update_price_from_pyth");
+    expect(json).toContain("get_price_info");
+    expect(json).toContain("update_price");
+    expect(json).not.toContain("parse_and_verify_le_ecdsa_update_v2");
+    expect(json).not.toContain("ingest_lazer_update");
+  });
+});
+
+describe("default price source (no premature cutover)", () => {
+  it("a fresh client defaults to Pyth (useLazer=false) on every network", () => {
+    for (const network of ["mainnet", "testnet", "devnet"] as Network[]) {
+      expect(new AlphalendClient(network).useLazer).toBe(false);
+    }
+  });
+});
+
+// Fail-closed at the CLIENT boundary (not just the fetch util): a proxy failure must reject the whole
+// refresh and never fall back to Pyth — a silent fallback would defeat the migration's price source.
+describe("Lazer fail-closed at the client boundary", () => {
+  it("propagates a proxy failure and never falls back to the Pyth path", async () => {
+    const client = new AlphalendClient("testnet", undefined, {
+      coinMetadataMap: new Map(),
+    });
+    client.useLazer = true;
+    installFetch().mockRejectedValue(new Error("ECONNREFUSED"));
+
+    const tx = new Transaction();
+    await expect(
+      client.updatePrices(tx, [client.constants.SUI_COIN_TYPE]),
+    ).rejects.toThrow();
+
+    // Nothing partial was built, and crucially no Pyth refresh was substituted in.
+    const json = JSON.stringify(tx.getData());
+    expect(json).not.toContain("update_price_from_pyth");
+    expect(json).not.toContain("ingest_lazer_update");
+  }, 15000);
+});

--- a/src/constants/devConstants.ts
+++ b/src/constants/devConstants.ts
@@ -70,15 +70,13 @@ export const devConstants: Constants = {
 
   PYTH_PRICE_PATH: "/api/latest_price_feeds",
 
-  // Pyth Lazer (Pyth Pro) Constants. LAZER_PACKAGE_ID = the package version exposing
-  // parse_and_verify_le_ecdsa_update_v2 (the PTB verify call). NOTE: testnet Lazer is STILL v1 (no _v2),
-  // so this PTB verify won't succeed on testnet until Pyth upgrades it — testnet e2e uses the
-  // controllable-signer harness instead (see oracle-migration/lazer-migration/testnet-e2e).
+  // Pyth Lazer (Pyth Pro) Constants. Testnet Pyth's canonical package is still v1 (no _v2), so testnet
+  // uses our published v2 verifier harness for the PTB verify call.
   LAZER_PACKAGE_ID:
-    "0xf5bd2141967507050a91b58de3d95e77c432cd90d1799ee46effc27430a68c21",
+    "0xf9686303df959b4b6a000fcac0befe0cc2cee24f2c2ec02dae914b3c525a5639",
 
   LAZER_STATE_ID:
-    "0xe2b9096a5ea341a9f1eef126b2203727e29e73fdb0641ade2e1e32942f97e4d8",
+    "0x470a1b15fae80369812c0f96f70788321f6f822ff8b8f35884743c175919fc39",
 
   // Backend proxy serving the signed payload at `${LAZER_PROXY_URL}/lazer/update`.
   LAZER_PROXY_URL: "https://api-staging.alphalend.xyz",

--- a/src/constants/devConstants.ts
+++ b/src/constants/devConstants.ts
@@ -70,6 +70,25 @@ export const devConstants: Constants = {
 
   PYTH_PRICE_PATH: "/api/latest_price_feeds",
 
+  // Pyth Lazer (Pyth Pro) Constants. LAZER_PACKAGE_ID = the package version exposing
+  // parse_and_verify_le_ecdsa_update_v2 (the PTB verify call). NOTE: testnet Lazer is STILL v1 (no _v2),
+  // so this PTB verify won't succeed on testnet until Pyth upgrades it — testnet e2e uses the
+  // controllable-signer harness instead (see oracle-migration/lazer-migration/testnet-e2e).
+  LAZER_PACKAGE_ID:
+    "0xf5bd2141967507050a91b58de3d95e77c432cd90d1799ee46effc27430a68c21",
+
+  LAZER_STATE_ID:
+    "0xe2b9096a5ea341a9f1eef126b2203727e29e73fdb0641ade2e1e32942f97e4d8",
+
+  // Backend proxy serving the signed payload at `${LAZER_PROXY_URL}/lazer/update`.
+  LAZER_PROXY_URL: "https://api-staging.alphalend.xyz",
+
+  // Per-network Lazer default; flip to `true` at cutover.
+  LAZER_ENABLED: false,
+
+  // Client-side freshness ceiling (ms); mirror of the proxy's LAZER_STALE_MS default.
+  LAZER_MAX_PROXY_AGE_MS: 3000,
+
   // Coin Types
   SUI_COIN_TYPE: "0x2::sui::SUI",
 

--- a/src/constants/prodConstants.ts
+++ b/src/constants/prodConstants.ts
@@ -71,6 +71,25 @@ export const prodConstants: Constants = {
 
   PYTH_PRICE_PATH: "/api/latest_price_feeds",
 
+  // Pyth Lazer (Pyth Pro) Constants.
+  // LAZER_PACKAGE_ID = the package VERSION exposing parse_and_verify_le_ecdsa_update_v2 (the v2 upgrade id),
+  // which the PTB calls to verify the signed update — NOT the type-origin id (0x7b50…f580). Only this
+  // constant moves when Pyth upgrades the verifier; the oracle never needs a republish.
+  LAZER_PACKAGE_ID:
+    "0xefbfd064480777699fd9c557a5804d72ace7bc82661fdc8d1f1a44ea6d92ee10",
+
+  LAZER_STATE_ID:
+    "0xd0db9c1e9212a98120384bf78d8b8c985d87b9ee6921dffcf9d1394062911573",
+
+  // Backend proxy serving the signed payload at `${LAZER_PROXY_URL}/lazer/update`.
+  LAZER_PROXY_URL: "https://api.alphalend.xyz",
+
+  // Per-network Lazer default; flip to `true` at cutover.
+  LAZER_ENABLED: false,
+
+  // Client-side freshness ceiling (ms); mirror of the proxy's LAZER_STALE_MS default.
+  LAZER_MAX_PROXY_AGE_MS: 3000,
+
   // Coin Types
   SUI_COIN_TYPE: "0x2::sui::SUI",
 

--- a/src/constants/types.ts
+++ b/src/constants/types.ts
@@ -50,6 +50,18 @@ export interface Constants {
 
   PYTH_PRICE_PATH: string;
 
+  // Pyth Lazer (Pyth Pro) Constants
+  LAZER_PACKAGE_ID: string;
+
+  LAZER_STATE_ID: string;
+
+  LAZER_PROXY_URL: string;
+
+  LAZER_ENABLED: boolean;
+
+  // Client-side freshness ceiling for the proxy payload (ms); mirror of the proxy's LAZER_STALE_MS.
+  LAZER_MAX_PROXY_AGE_MS: number;
+
   // Coin Types
   SUI_COIN_TYPE: string;
 

--- a/src/core/client.ts
+++ b/src/core/client.ts
@@ -15,9 +15,11 @@ import {
   TransactionArgument,
 } from "@mysten/sui/transactions";
 import {
+  appendOracleToLendingBridge,
   getPriceInfoObjectIdsWithUpdate,
   updatePriceTransaction,
 } from "../utils/oracle.js";
+import { appendLazerUpdate, fetchLazerUpdateBytes } from "../utils/lazer.js";
 import {
   SupplyParams,
   WithdrawParams,
@@ -81,6 +83,9 @@ export class AlphalendClient {
   sevenKGateway: SevenKGateway;
   cetusSwap: CetusSwap;
 
+  /** When true, refreshes use the on-demand Lazer path instead of Pyth. Set from the `LAZER_ENABLED` constant. */
+  useLazer: boolean;
+
   // Dynamic coin metadata properties
   private coinMetadataMap: Map<string, CoinMetadata> = new Map();
   private isInitialized: boolean = false;
@@ -140,6 +145,7 @@ export class AlphalendClient {
     this.blockchain = new Blockchain(network, graphqlUrl);
     this.sevenKGateway = new SevenKGateway();
     this.cetusSwap = new CetusSwap("mainnet");
+    this.useLazer = this.constants.LAZER_ENABLED;
 
     // If a coin metadata map is provided, use it and mark as initialized
     if (options?.coinMetadataMap) {
@@ -160,6 +166,42 @@ export class AlphalendClient {
   }
 
   /**
+   * Fetches the signed payload from the backend proxy (the token must never reach the client), then:
+   *   1. verifies it in-PTB + `oracle::ingest_lazer_update` → refreshes every tracked feed in the GLOBAL
+   *      alphafi_oracle (one call, all feeds);
+   *   2. per coin, bridges that fresh price into the LendingProtocol's embedded `protocol.oracle` via
+   *      `alpha_lending::update_price` — the source supply/withdraw/borrow actually read. Without step 2,
+   *      ops would read a stale `protocol.oracle` and abort on the freshness gate. Mirrors the Pyth path.
+   */
+  //TODO: What happens if this throws?
+  async updatePricesLazer(tx: Transaction, coinTypes: string[]): Promise<void> {
+    await this.ensureInitialized();
+    const bytes = await fetchLazerUpdateBytes(
+      this.constants.LAZER_PROXY_URL,
+      this.constants.LAZER_MAX_PROXY_AGE_MS,
+    );
+    // Mirror the Pyth writer: pass the global Oracle's initial shared version so ingest_lazer_update
+    // references it as an explicit mutable SharedObjectRef (same as update_price_from_pyth).
+    const oracleInitialSharedVersion =
+      await this.blockchain.getInitialSharedVersion(
+        this.constants.ALPHAFI_ORACLE_OBJECT_ID,
+      );
+    appendLazerUpdate(
+      tx,
+      this.constants.LAZER_PACKAGE_ID,
+      this.constants.ALPHAFI_LATEST_ORACLE_PACKAGE_ID,
+      this.constants.ALPHAFI_ORACLE_OBJECT_ID,
+      oracleInitialSharedVersion,
+      this.constants.LAZER_STATE_ID,
+      bytes,
+    );
+    /// TODO: THIS WILL BREAK PARITY BETWEEN THE TWO ORACLES
+    for (const coinType of new Set(coinTypes)) {
+      appendOracleToLendingBridge(tx, coinType, this.constants);
+    }
+  }
+
+  /**
    * Updates price information for assets from Pyth oracle
    *
    * This method:
@@ -173,6 +215,10 @@ export class AlphalendClient {
    * @returns Transaction object with price update calls
    */
   async updatePrices(tx: Transaction, coinTypes: string[]) {
+    if (this.useLazer) {
+      await this.updatePricesLazer(tx, coinTypes);
+      return;
+    }
     // Auto-initialize market data if needed
     await this.ensureInitialized();
 
@@ -212,6 +258,10 @@ export class AlphalendClient {
   }
 
   async updateAllPrices(tx: Transaction, coinTypes: string[]) {
+    if (this.useLazer) {
+      await this.updatePricesLazer(tx, coinTypes);
+      return;
+    }
     // Auto-initialize market data if needed
     await this.ensureInitialized();
 

--- a/src/core/client.ts
+++ b/src/core/client.ts
@@ -195,7 +195,13 @@ export class AlphalendClient {
       this.constants.LAZER_STATE_ID,
       bytes,
     );
-    /// TODO: THIS WILL BREAK PARITY BETWEEN THE TWO ORACLES
+    // ingest_lazer_update above refreshed EVERY tracked feed in the global alphafi_oracle, but we only
+    // bridge the coins this tx touches into the LendingProtocol's embedded oracle — so the two oracles
+    // diverge (the global one is fresher for coins not in `coinTypes`). This is safe by design: the global
+    // oracle is the source of truth, the embedded one is a per-tx working set, and alpha_lending::verify_price
+    // only reads the coins actually used here. Every coin a position touches is passed in `coinTypes` (the
+    // same contract the Pyth path relies on), so the un-bridged coins are never read this tx. Bridging all
+    // ~35 tracked coins on every tx would be wasteful and pointless.
     for (const coinType of new Set(coinTypes)) {
       appendOracleToLendingBridge(tx, coinType, this.constants);
     }

--- a/src/utils/lazer.ts
+++ b/src/utils/lazer.ts
@@ -1,0 +1,103 @@
+/**
+ * Pyth Lazer price path: fetch one signed payload from the backend proxy, then IN THE PTB verify it via the
+ * real on-chain `pyth_lazer` package and feed the verified `Update` to `oracle::ingest_lazer_update`. The
+ * access token must never reach the browser, so the payload comes from the proxy, not the official
+ * token+WebSocket client.
+ */
+import { Inputs, Transaction } from "@mysten/sui/transactions";
+import { SUI_CLOCK_OBJECT_ID, fromHex } from "@mysten/sui/utils";
+
+/**
+ * Fetch one fresh signed Lazer `update` blob from the backend proxy (`GET {proxyUrl}/lazer/update`),
+ * ready for {@link appendLazerUpdate}. `maxAgeMs` (the per-network `LAZER_MAX_PROXY_AGE_MS` constant,
+ * mirroring the proxy's own `LAZER_STALE_MS`) is the client-side freshness ceiling. Retries transient
+ * failures with exponential backoff + jitter (the proxy 503s briefly during a Lazer WS reconnect; `fetch`
+ * has no built-in retry), then fails closed — no Pyth fallback.
+ */
+export async function fetchLazerUpdateBytes(
+  proxyUrl: string,
+  maxAgeMs: number,
+): Promise<Uint8Array> {
+  const url = `${proxyUrl.replace(/\/+$/, "")}/lazer/update`;
+  const attempts = 3;
+  let lastErr: unknown;
+  for (let attempt = 1; attempt <= attempts; attempt++) {
+    try {
+      const response = await fetch(url);
+      if (!response.ok) {
+        throw new Error(`Lazer proxy request failed: ${response.status}`);
+      }
+      const { hex, ageMs } = (await response.json()) as {
+        hex: string;
+        ageMs: number;
+      };
+      // Fail closed: the proxy always sends ageMs on a 200 (and 503s when stale), so a missing/NaN
+      // value means a malformed or wrong endpoint — never silently skip the freshness gate.
+      if (typeof ageMs !== "number" || Number.isNaN(ageMs)) {
+        throw new Error("Lazer proxy response missing ageMs");
+      }
+      if (ageMs > maxAgeMs) {
+        throw new Error(`Lazer proxy payload is stale: ${ageMs}ms`);
+      }
+      return fromHex(hex);
+    } catch (e) {
+      lastErr = e;
+      if (attempt < attempts) {
+        // Exponential backoff with jitter (~600ms, ~1200ms). The proxy 503s during a Lazer WS reconnect
+        // whose supervisor sleeps ~1s between attempts, so the total retry window must exceed that 1s — a
+        // linear ~900ms budget could give up mid-reconnect. Jitter avoids a thundering herd of clients
+        // retrying in lockstep after a shared blip.
+        const backoffMs = 300 * 2 ** attempt + Math.floor(Math.random() * 150);
+        await new Promise((r) => setTimeout(r, backoffMs));
+      }
+    }
+  }
+  throw lastErr;
+}
+
+/**
+ * Append the permissionless Lazer refresh to a PTB before any oracle price read. Two move calls:
+ *   1. verify the signed Lazer update IN THE PTB via the real on-chain `pyth_lazer` package (Pyth's
+ *      "verify in PTBs, not contracts" model) → a verified `Update`;
+ *   2. hand that `Update` to `oracle::ingest_lazer_update`, which writes every tracked feed it carries.
+ * Verifying in the PTB means our oracle never links the verifier fn, so a Pyth verifier upgrade only
+ * changes `lazerPackageId` here — no oracle republish. One call refreshes every feed in `updateBytes`.
+ *
+ * `lazerPackageId` MUST be the package version exposing `parse_and_verify_le_ecdsa_update_v2` (the v2 id),
+ * not the type-origin id. `oracleInitialSharedVersion` is the global Oracle's initial shared version —
+ * passed so the mutating `ingest_lazer_update` references the Oracle as an explicit mutable
+ * `SharedObjectRef`, exactly like the Pyth writer (`update_price_from_pyth`) it replaces.
+ */
+export function appendLazerUpdate(
+  tx: Transaction,
+  lazerPackageId: string,
+  oraclePackageId: string,
+  oracleObjectId: string,
+  oracleInitialSharedVersion: string,
+  lazerStateId: string,
+  updateBytes: Uint8Array,
+): void {
+  const verifiedUpdate = tx.moveCall({
+    target: `${lazerPackageId}::pyth_lazer::parse_and_verify_le_ecdsa_update_v2`,
+    arguments: [
+      tx.object(lazerStateId),
+      tx.object(SUI_CLOCK_OBJECT_ID),
+      tx.pure.vector("u8", Array.from(updateBytes)),
+    ],
+  });
+  tx.moveCall({
+    target: `${oraclePackageId}::oracle::ingest_lazer_update`,
+    arguments: [
+      // Explicit mutable shared ref + initial shared version, mirroring update_price_from_pyth.
+      tx.object(
+        Inputs.SharedObjectRef({
+          objectId: oracleObjectId,
+          initialSharedVersion: oracleInitialSharedVersion,
+          mutable: true,
+        }),
+      ),
+      verifiedUpdate,
+      tx.object(SUI_CLOCK_OBJECT_ID),
+    ],
+  });
+}

--- a/src/utils/oracle.ts
+++ b/src/utils/oracle.ts
@@ -70,6 +70,36 @@ export async function getPriceInfoObjectIdsWithoutUpdate(
 }
 
 /**
+ * Bridges a coin's fresh price from the global alphafi_oracle into the LendingProtocol's embedded
+ * oracle (`protocol.oracle`) — the price source every supply/withdraw/borrow/liquidate actually reads.
+ * Shared by the Pyth and Lazer refresh paths so the two stay identical.
+ *
+ * @param tx - The transaction to add the bridge calls to
+ * @param coinType - The fully qualified coin type to bridge
+ * @param constants - Protocol constants
+ */
+export function appendOracleToLendingBridge(
+  tx: Transaction,
+  coinType: string,
+  constants: Constants,
+) {
+  const coinTypeName = tx.moveCall({
+    target: `0x1::type_name::get`,
+    typeArguments: [coinType],
+  });
+
+  const oraclePriceInfo = tx.moveCall({
+    target: `${constants.ALPHAFI_LATEST_ORACLE_PACKAGE_ID}::oracle::get_price_info`,
+    arguments: [tx.object(constants.ALPHAFI_ORACLE_OBJECT_ID), coinTypeName],
+  });
+
+  tx.moveCall({
+    target: `${constants.ALPHALEND_LATEST_PACKAGE_ID}::alpha_lending::update_price`,
+    arguments: [tx.object(constants.LENDING_PROTOCOL_ID), oraclePriceInfo],
+  });
+}
+
+/**
  * Adds oracle price update instructions to a transaction
  *
  * @param tx - The transaction to add price updates to
@@ -98,18 +128,5 @@ export function updatePriceTransaction(
     ],
   });
 
-  const coinTypeName = tx.moveCall({
-    target: `0x1::type_name::get`,
-    typeArguments: [args.coinType],
-  });
-
-  const oraclePriceInfo = tx.moveCall({
-    target: `${constants.ALPHAFI_LATEST_ORACLE_PACKAGE_ID}::oracle::get_price_info`,
-    arguments: [tx.object(constants.ALPHAFI_ORACLE_OBJECT_ID), coinTypeName],
-  });
-
-  tx.moveCall({
-    target: `${constants.ALPHALEND_LATEST_PACKAGE_ID}::alpha_lending::update_price`,
-    arguments: [tx.object(constants.LENDING_PROTOCOL_ID), oraclePriceInfo],
-  });
+  appendOracleToLendingBridge(tx, args.coinType, constants);
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,6 +7,8 @@
   "compilerOptions": {
     "module": "NodeNext",
     "moduleResolution": "NodeNext",
+    "rootDir": ".",
     "noEmit": true
-  }
+  },
+  "include": ["src/**/*", "__tests__/**/*"]
 }


### PR DESCRIPTION
## Summary

Adds a Pyth **Lazer** (Pyth Pro) price-refresh path to the SDK, behind the
`LAZER_ENABLED` flag (default **false**). Pyth remains the active path; nothing
changes in production on merge. Flipping the flag at cutover routes all price
refreshes through Lazer.

Pyth Core is being retired on Sui (OP-PIP-100; hard deadline ~Jul 31 2026), so
this is the SDK half of the on-chain Pyth→Lazer oracle migration.

## How it works

The global `alphafi_oracle` stores one price per coin; the reader
(`get_price_info` / `alpha_lending::verify_price`) is source-agnostic. A "source"
is just whichever writer refreshes that slot. This PR adds Lazer as that writer,
following Pyth's **"verify in PTBs, not contracts"** model:

1. Fetch one signed payload (all feeds) from the backend proxy
   (`GET ${LAZER_PROXY_URL}/lazer/update`) — the Pyth Pro token never reaches the client.
2. In the PTB: `pyth_lazer::parse_and_verify_le_ecdsa_update_v2` (verify) →
   `oracle::ingest_lazer_update` (writes every tracked feed into the global oracle).
3. Per coin: bridge the fresh price into the LendingProtocol's embedded oracle
   (`get_price_info` → `alpha_lending::update_price`).

Because verification runs in the PTB, the oracle never links the verifier
function — a future Pyth verifier upgrade only changes the off-chain
`LAZER_PACKAGE_ID`, with no oracle republish. The global Oracle is passed to
`ingest_lazer_update` as an explicit mutable `SharedObjectRef` (via
`getInitialSharedVersion`), mirroring `update_price_from_pyth`.

## Changes

- `src/utils/lazer.ts` *(new)* — `fetchLazerUpdateBytes` (proxy fetch: staleness gate, retry, fail-closed) + `appendLazerUpdate` (verify-in-PTB → `ingest_lazer_update`)
- `src/utils/oracle.ts` — extract `appendOracleToLendingBridge` (shared by Pyth & Lazer); the Pyth path is behavior-preserving
- `src/core/client.ts` — `updatePricesLazer`; `updatePrices`/`updateAllPrices` route via `useLazer` (`= LAZER_ENABLED`)
- `src/constants/{prod,dev}Constants.ts` + `types.ts` — `LAZER_PACKAGE_ID` (v2 verifier id), `LAZER_STATE_ID`, `LAZER_PROXY_URL`, `LAZER_ENABLED`, `LAZER_MAX_PROXY_AGE_MS`
- `__tests__/lazer.test.ts` *(new)* — proxy fetch (fresh/stale/retry/fail-closed), PTB shape, bridge, `useLazer` routing
- `__tests__/lazer.e2e.test.ts` *(new)* — mock-signer testnet e2e (gasless `devInspect`): proves the PTB the SDK builds is accepted by the **real on-chain Lazer verifier** and `ingest_lazer_update` writes end-to-end. Gated behind `LAZER_E2E=1` (CI skips it); run with `LAZER_E2E=1 npm test -- lazer.e2e`
- `tsconfig.json` — include `__tests__` for editor type-checking (the build config `tsconfig.esm.json` still excludes tests, so build/CI are unchanged)

## Safety

- **Flag-gated, default off** → zero production behavior change on merge; the Pyth path is untouched.
- `alpha_lending` and the oracle reader are unchanged (source-agnostic by design).
- Rollback after cutover = flip `LAZER_ENABLED` back.

## Verification

- `npm run build` ✓ · `npm run lint` ✓ · `npm test` ✓ (56 passed, 1 e2e suite skipped, 0 failed)
- On-chain shape proven via the gated mock-signer e2e (`LAZER_E2E=1`): verify → ingest → read back in one `devInspect`.

## Depends on / cutover notes

- **Requires the on-chain `ingest_lazer_update` oracle upgrade to be published on mainnet** before `LAZER_ENABLED` can be flipped (today's oracle only has `update_price_from_pyth`).
- Remaining before flip: a real Pyth-token-signed payload run + mainnet validation.
- Pair with: `alphalend-sdk-rust` call-site flip, and the off-chain `pythPrice` display value (alphalend-api / data-sdk).

## Out of scope (follow-ups)

- Deleting the Pyth path/deps — post-cutover cleanup once Lazer is proven live.
- `coinMetadata.pythPrice` → Lazer-sourced display price (alphalend-api + data-sdk + FE).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
