### PR TITLE
Convert SUI rewards to stSUI in claim flows and portfolio

### DIFF
--- a/scripts/testRun.ts
+++ b/scripts/testRun.ts
@@ -1,11 +1,11 @@
 import { Ed25519Keypair } from "@mysten/sui/keypairs/ed25519";
 import { Transaction } from "@mysten/sui/transactions";
-import { fromB64 } from "@mysten/sui/utils";
+import { fromBase64 } from "@mysten/sui/utils";
 import { getConstants } from "../src/constants/index.js";
 import { AlphalendClient } from "../src/core/client.js";
 import * as dotenv from "dotenv";
 import { setPrices } from "../src/utils/helper.js";
-import { SuiClient } from "@mysten/sui/client";
+import { SuiJsonRpcClient } from "@mysten/sui/jsonRpc";
 import {
   SuiPriceServiceConnection,
   SuiPythClient,
@@ -25,8 +25,9 @@ export function getSuiClient(network?: string) {
     rpcUrl = testnetUrl;
   }
 
-  return new SuiClient({
+  return new SuiJsonRpcClient({
     url: rpcUrl,
+    network: network ?? "mainnet",
   });
 }
 
@@ -38,7 +39,9 @@ export function getExecStuff() {
   }
 
   const b64PrivateKey = process.env.PK_B64 as string;
-  const keypair = Ed25519Keypair.fromSecretKey(fromB64(b64PrivateKey).slice(1));
+  const keypair = Ed25519Keypair.fromSecretKey(
+    fromBase64(b64PrivateKey).slice(1),
+  );
   const address = `${keypair.getPublicKey().toSuiAddress()}`;
 
   if (!process.env.NETWORK) {
@@ -50,8 +53,11 @@ export function getExecStuff() {
   return { address, keypair, suiClient };
 }
 
-export async function dryRunTransactionBlock(txb: Transaction) {
-  const { suiClient, address } = getExecStuff();
+export async function dryRunTransactionBlock(
+  txb: Transaction,
+  address: string,
+) {
+  const { suiClient } = getExecStuff();
   txb.setSender(address);
   txb.setGasBudget(1e9);
   try {
@@ -87,17 +93,18 @@ async function claimRewards() {
   let tx: Transaction | undefined = new Transaction();
   // await addCoinToOracleCaller(tx);
   await setPrices(tx);
+  const address =
+    "0xa511088cc13a632a5e8f9937028a77ae271832465e067360dd13f548fe934d1a";
   const alc = new AlphalendClient("testnet");
   tx = await alc.claimRewards({
-    address:
-      "0xa511088cc13a632a5e8f9937028a77ae271832465e067360dd13f548fe934d1a",
+    address: address,
     positionCapId:
       "0x8465d2416b01d3e76460912cd290e5dd9c4a36cfbe52f348cfe04e8ae769de4e",
     claimAll: false,
     claimAlpha: false,
   });
   if (tx) {
-    dryRunTransactionBlock(tx);
+    dryRunTransactionBlock(tx, address);
   }
 }
 
@@ -140,9 +147,10 @@ async function zapInSupply() {
 
 async function borrow() {
   const alc = new AlphalendClient("testnet");
+  const address =
+    "0x8948f801fa2325eedb4b0ad4eb0a55bfb318acc531f3a2f0cddd8daa9b4a8c94";
   const tx: Transaction | undefined = await alc.borrow({
-    address:
-      "0x8948f801fa2325eedb4b0ad4eb0a55bfb318acc531f3a2f0cddd8daa9b4a8c94",
+    address: address,
     positionCapId:
       "0x04aef463126fea9cc518a37abc8ae8367f68c8eceeef31790b2da6be852d9d4b",
     coinType:
@@ -152,7 +160,7 @@ async function borrow() {
     priceUpdateCoinTypes: [],
   });
   if (tx) {
-    dryRunTransactionBlock(tx);
+    dryRunTransactionBlock(tx, address);
   }
 }
 
@@ -216,26 +224,25 @@ async function getUserPortfolio() {
 
 async function withdraw() {
   const alc = new AlphalendClient("mainnet");
+  const address =
+    "0x8c5c76fa46a645ce5f636342ad6b0514a55f8c1518671920cd92d284695aff78";
   const tx: Transaction | undefined = await alc.withdraw({
-    address:
-      "0xe136f0b6faf27ee707725f38f2aeefc51c6c31cc508222bee5cbc4f5fcf222c3",
+    address: address,
     positionCapId:
-      "0xf9ca35f404dd3c1ea10c381dd3e1fe8a0c4586adf5e186f4eb52307462a5af7d",
+      "0x8de2193d00fe660a90d823125fbd300774dbba553d9eb353e7451c419fe55a8d",
     coinType:
-      "0xd1b72982e40348d069bb1ff701e634c117bb5f741f44dff91e472d3b01461e55::stsui::STSUI",
-    marketId: "2",
-    amount: 100_000_000n,
+      "0x66629328922d609cf15af779719e248ae0e63fe0b9d9739623f763b33a9c97da::esui::ESUI",
+    marketId: "21",
+    amount: 10_000_000_000n,
     priceUpdateCoinTypes: [
-      "0x375f70cf2ae4c00bf37117d0c85a2c71545e6ee05c4a5c7d282cd66a4504b068::usdt::USDT",
+      "0x66629328922d609cf15af779719e248ae0e63fe0b9d9739623f763b33a9c97da::esui::ESUI",
       "0xd1b72982e40348d069bb1ff701e634c117bb5f741f44dff91e472d3b01461e55::stsui::STSUI",
-      "0xdeeb7a4662eec9f2f3def03fb937a663dddaa2e215b8078a284d026b7946c270::deep::DEEP",
-      "0x356a26eb9e012a68958082340d4c4116e7f55615cf27affcff209cf0ae544f59::wal::WAL",
-      "0xe1b45a0e641b9955a20aa0ad1c1f4ad86aad8afb07296d4085e349a50e90bdca::blue::BLUE",
-      "0x4c981f3ff786cdb9e514da897ab8a953647dae2ace9679e8358eec1e3e8871ac::dmc::DMC",
+      "0x7262fb2f7a3a14c888c438a3cd9b912469a58cf60f367352c46584262e8299aa::ika::IKA",
+      "0x2::sui::SUI",
     ],
   });
   if (tx) {
-    dryRunTransactionBlock(tx);
+    dryRunTransactionBlock(tx, address);
   }
 }
 withdraw();

--- a/scripts/updatePriceScript.ts
+++ b/scripts/updatePriceScript.ts
@@ -2,7 +2,7 @@ import cron from "node-cron";
 import { AlphalendClient } from "../src/core/client";
 import { Transaction } from "@mysten/sui/transactions";
 import { getExecStuff } from "./testRun";
-import { SuiTransactionBlockResponse } from "@mysten/sui/client";
+import { SuiTransactionBlockResponse } from "@mysten/sui/jsonRpc";
 
 cron.schedule("* * * * *", async () => {
   const { suiClient, keypair } = getExecStuff();

--- a/scripts/utils.ts
+++ b/scripts/utils.ts
@@ -1,6 +1,6 @@
-import { fromB64 } from "@mysten/bcs";
+import { fromBase64 } from "@mysten/bcs";
 import { Ed25519Keypair } from "@mysten/sui/keypairs/ed25519";
-import { SuiClient, getFullnodeUrl } from "@mysten/sui/client";
+import { SuiJsonRpcClient, getJsonRpcFullnodeUrl } from "@mysten/sui/jsonRpc";
 
 import * as dotenv from "dotenv";
 import { Transaction } from "@mysten/sui/transactions";
@@ -13,15 +13,17 @@ export function getExecStuff() {
   }
 
   const b64PrivateKey = process.env.PK_B64 as string;
-  const keypair = Ed25519Keypair.fromSecretKey(fromB64(b64PrivateKey).slice(1));
+  const keypair = Ed25519Keypair.fromSecretKey(
+    fromBase64(b64PrivateKey).slice(1),
+  );
   const address = `${keypair.getPublicKey().toSuiAddress()}`;
 
   if (!process.env.NETWORK) {
     throw new Error("env var NETWORK not configured");
   }
 
-  const suiClient = new SuiClient({
-    url: getFullnodeUrl(
+  const suiClient = new SuiJsonRpcClient({
+    url: getJsonRpcFullnodeUrl(
       process.env.NETWORK as "mainnet" | "testnet" | "devnet" | "localnet",
     ),
   });

--- a/src/constants/devConstants.ts
+++ b/src/constants/devConstants.ts
@@ -97,6 +97,15 @@ export const devConstants: Constants = {
   STSUI_COIN_TYPE:
     "0xd1b72982e40348d069bb1ff701e634c117bb5f741f44dff91e472d3b01461e55::stsui::STSUI",
 
+  // SUI -> stSUI reward conversion is mainnet-only; these mirror prod for shape.
+  STSUI_LATEST_PACKAGE_ID:
+    "0x059f94b85c07eb74d2847f8255d8cc0a67c9a8dcc039eabf9f8b9e23a0de2700",
+
+  LST_INFO:
+    "0x1adb343ab351458e151bc392fbf1558b3332467f23bda45ae67cd355a57fd5f5",
+
+  STSUI_MARKET_ID: 2,
+
   ALPHA_COIN_TYPE: "",
 
   SUI_COIN_TYPE_LONG:

--- a/src/constants/prodConstants.ts
+++ b/src/constants/prodConstants.ts
@@ -96,6 +96,14 @@ export const prodConstants: Constants = {
   STSUI_COIN_TYPE:
     "0xd1b72982e40348d069bb1ff701e634c117bb5f741f44dff91e472d3b01461e55::stsui::STSUI",
 
+  STSUI_LATEST_PACKAGE_ID:
+    "0x059f94b85c07eb74d2847f8255d8cc0a67c9a8dcc039eabf9f8b9e23a0de2700",
+
+  LST_INFO:
+    "0x1adb343ab351458e151bc392fbf1558b3332467f23bda45ae67cd355a57fd5f5",
+
+  STSUI_MARKET_ID: 2,
+
   ALPHA_COIN_TYPE:
     "0xfe3afec26c59e874f3c1d60b8203cb3852d2bb2aa415df9548b8d688e6683f93::alpha::ALPHA",
 

--- a/src/constants/types.ts
+++ b/src/constants/types.ts
@@ -70,6 +70,13 @@ export interface Constants {
 
   STSUI_COIN_TYPE: string;
 
+  // stSUI liquid staking (SUI reward -> stSUI conversion)
+  STSUI_LATEST_PACKAGE_ID: string;
+
+  LST_INFO: string;
+
+  STSUI_MARKET_ID: number;
+
   ALPHA_COIN_TYPE: string;
 
   SUI_COIN_TYPE_LONG: string;

--- a/src/core/client.ts
+++ b/src/core/client.ts
@@ -64,7 +64,7 @@ import { buildFlashRepayTransaction } from "./flashRepay.js";
 // Minimum estimated SUI reward (in MIST) to route through liquid_staking::mint.
 // The stSUI contract aborts with EZeroLstMinted when the post-fee amount rounds
 // to zero stSUI, so dust falls back to plain SUI handling.
-const MIN_SUI_STAKE_AMOUNT = 10_000_000n; // 0.01 SUI
+const MIN_SUI_STAKE_AMOUNT = 3n; // 3 mists
 
 /**
  * AlphaLend Client

--- a/src/core/client.ts
+++ b/src/core/client.ts
@@ -61,6 +61,11 @@ import { blockchainCache } from "../utils/blockchainCache.js";
 import { CetusSwap, RouterDataV3 } from "./cetusSwap.js";
 import { buildFlashRepayTransaction } from "./flashRepay.js";
 
+// Minimum estimated SUI reward (in MIST) to route through liquid_staking::mint.
+// The stSUI contract aborts with EZeroLstMinted when the post-fee amount rounds
+// to zero stSUI, so dust falls back to plain SUI handling.
+const MIN_SUI_STAKE_AMOUNT = 10_000_000n; // 0.01 SUI
+
 /**
  * AlphaLend Client
  *
@@ -266,7 +271,9 @@ export class AlphalendClient {
 
     // Use dynamic data with fallback to hardcoded
     const updatePriceFeedIds: string[] = Array.from(
-      new Set(uniqueCoinTypes.map((coinType) => this.getPythPriceFeedId(coinType))),
+      new Set(
+        uniqueCoinTypes.map((coinType) => this.getPythPriceFeedId(coinType)),
+      ),
     );
 
     // The Pyth fetch and resolving the oracle's initial shared version are
@@ -1038,6 +1045,11 @@ export class AlphalendClient {
    * @param params.claimAll Whether to claim and deposit all other reward tokens
    * @param params.claimAndDepositAlpha Whether to claim and deposit Alpha token rewards
    * @param params.claimAndDepositAll Whether to claim and deposit all other reward tokens
+   *
+   * On mainnet, SUI rewards are staked into stSUI via `liquid_staking::mint` and
+   * the stSUI is transferred to the user (or supplied to the stSUI market when
+   * `claimAndDepositAll` is set). Dust SUI rewards below 0.01 SUI keep the plain
+   * SUI behavior.
    * @returns Transaction object ready for signing and execution
    */
   async claimRewards(params: ClaimRewardsParams): Promise<Transaction> {
@@ -1046,21 +1058,30 @@ export class AlphalendClient {
       params.claimAndDepositAlpha || params.claimAlpha;
     params.claimAndDepositAll = params.claimAndDepositAll || params.claimAll;
 
-    const rewardInput = await getClaimRewardInput(
+    const { rewardInput, claimableAmounts } = await getClaimRewardInput(
       this.blockchain,
       params.address,
       params.positionCapId,
     );
 
+    const convertSuiToStsui =
+      this.network === "mainnet" &&
+      (claimableAmounts.get(this.constants.SUI_COIN_TYPE) ?? 0n) >=
+        MIN_SUI_STAKE_AMOUNT;
+
     let alphaCoin: TransactionObjectArgument | undefined = undefined;
+    let suiCoin: TransactionObjectArgument | undefined = undefined;
     for (const data of rewardInput) {
       for (let coinType of data.coinTypes) {
         coinType = normalizeCoinType(coinType);
+        const isSuiConversion =
+          convertSuiToStsui && coinType === this.constants.SUI_COIN_TYPE;
         let coin1: TransactionObjectArgument | undefined;
         let promise: TransactionObjectArgument | undefined;
         if (
           params.claimAndDepositAll &&
-          coinType !== this.constants.ALPHA_COIN_TYPE
+          coinType !== this.constants.ALPHA_COIN_TYPE &&
+          !isSuiConversion
         ) {
           [coin1, promise] = tx.moveCall({
             target: `${this.constants.ALPHALEND_LATEST_PACKAGE_ID}::alpha_lending::collect_reward_and_deposit`,
@@ -1097,6 +1118,13 @@ export class AlphalendClient {
             if (coin1) {
               alphaCoin = this.mergeCoins(tx, alphaCoin, [coin1]);
             }
+          } else if (isSuiConversion) {
+            if (coin2) {
+              suiCoin = this.mergeCoins(tx, suiCoin, [coin2]);
+            }
+            if (coin1) {
+              suiCoin = this.mergeCoins(tx, suiCoin, [coin1]);
+            }
           } else {
             if (coin2) {
               this.sendCoinToAddressBalance(
@@ -1121,10 +1149,35 @@ export class AlphalendClient {
             coinType === this.constants.ALPHA_COIN_TYPE
           ) {
             alphaCoin = this.mergeCoins(tx, alphaCoin, [coin1]);
+          } else if (isSuiConversion) {
+            suiCoin = this.mergeCoins(tx, suiCoin, [coin1]);
           } else {
             this.sendCoinToAddressBalance(tx, coinType, params.address, coin1);
           }
         }
+      }
+    }
+    if (suiCoin) {
+      const stsuiCoin = this.mintStsui(tx, suiCoin);
+      if (params.claimAndDepositAll) {
+        tx.moveCall({
+          target: `${this.constants.ALPHALEND_LATEST_PACKAGE_ID}::alpha_lending::add_collateral`,
+          typeArguments: [this.constants.STSUI_COIN_TYPE],
+          arguments: [
+            tx.object(this.constants.LENDING_PROTOCOL_ID),
+            tx.object(params.positionCapId),
+            tx.pure.u64(this.constants.STSUI_MARKET_ID),
+            stsuiCoin,
+            tx.object(this.constants.SUI_CLOCK_OBJECT_ID),
+          ],
+        });
+      } else {
+        this.sendCoinToAddressBalance(
+          tx,
+          this.constants.STSUI_COIN_TYPE,
+          params.address,
+          stsuiCoin,
+        );
       }
     }
     if (alphaCoin) {
@@ -1132,6 +1185,26 @@ export class AlphalendClient {
     }
 
     return tx;
+  }
+
+  /**
+   * Stakes a SUI coin into stSUI via `liquid_staking::mint`.
+   * Aborts on-chain with EZeroLstMinted if the post-fee amount rounds to zero.
+   */
+  private mintStsui(
+    tx: Transaction,
+    suiCoin: TransactionObjectArgument,
+  ): TransactionObjectArgument {
+    const [stsuiCoin] = tx.moveCall({
+      target: `${this.constants.STSUI_LATEST_PACKAGE_ID}::liquid_staking::mint`,
+      typeArguments: [this.constants.STSUI_COIN_TYPE],
+      arguments: [
+        tx.object(this.constants.LST_INFO),
+        tx.object(this.constants.SUI_SYSTEM_STATE_ID),
+        suiCoin,
+      ],
+    });
+    return stsuiCoin;
   }
 
   /**
@@ -1175,11 +1248,15 @@ export class AlphalendClient {
     // ensureInitialized (coin metadata fetch) and getClaimRewardInput (position
     // + market reads) are independent network round-trips, so run them
     // concurrently instead of sequentially.
-    const [, rewardInput] = await Promise.all([
+    const [, { rewardInput }] = await Promise.all([
       // Ensure SDK is initialized to have access to coin metadata (including prices)
       this.ensureInitialized(),
       // Get all claimable rewards
-      getClaimRewardInput(this.blockchain, params.address, params.positionCapId),
+      getClaimRewardInput(
+        this.blockchain,
+        params.address,
+        params.positionCapId,
+      ),
     ]);
 
     if (!rewardInput || rewardInput.length === 0) {
@@ -1416,6 +1493,10 @@ export class AlphalendClient {
    *
    * Note: reward coin types that are not present in `borrowedCoins` are currently not processed.
    *
+   * On mainnet, SUI rewards are staked into stSUI via `liquid_staking::mint` and
+   * processed as stSUI, so `borrowedCoins`/`supplyMarkets` lookups run against the
+   * stSUI coin type. Dust SUI rewards below 0.01 SUI keep the plain SUI behavior.
+   *
    * On mainnet, optionally updates prices first if `priceUpdateCoinTypes` is provided.
    *
    * @param params ClaimAndSupplyOrRepayParams - claim + repay configuration
@@ -1435,12 +1516,21 @@ export class AlphalendClient {
     // (position + market reads) are independent network round-trips, so run them
     // concurrently. updatePrices still appends its price-update calls before the
     // reward-collection loop below, preserving transaction ordering.
-    const [, rewardInput] = await Promise.all([
+    const [, { rewardInput, claimableAmounts }] = await Promise.all([
       shouldUpdatePrices
         ? this.updatePrices(tx, params.priceUpdateCoinTypes!)
         : Promise.resolve(),
-      getClaimRewardInput(this.blockchain, params.address, params.positionCapId),
+      getClaimRewardInput(
+        this.blockchain,
+        params.address,
+        params.positionCapId,
+      ),
     ]);
+
+    const convertSuiToStsui =
+      this.network === "mainnet" &&
+      (claimableAmounts.get(this.constants.SUI_COIN_TYPE) ?? 0n) >=
+        MIN_SUI_STAKE_AMOUNT;
 
     // Collect rewards for each market and coin type
     const rewardCoinsByType = new Map<string, TransactionObjectArgument[]>();
@@ -1457,13 +1547,18 @@ export class AlphalendClient {
       }
     };
 
+    const suiCoins: TransactionObjectArgument[] = [];
     for (const data of rewardInput) {
       for (let coinType of data.coinTypes) {
         coinType = normalizeCoinType(coinType);
+        // SUI destined for stSUI must be collected without the on-chain
+        // auto-deposit so the coin is available to stake.
+        const isSuiConversion =
+          convertSuiToStsui && coinType === this.constants.SUI_COIN_TYPE;
 
         // Collect reward for this coin type
         const [coin1, promise] = tx.moveCall({
-          target: `${this.constants.ALPHALEND_LATEST_PACKAGE_ID}::alpha_lending::collect_reward_and_deposit`,
+          target: `${this.constants.ALPHALEND_LATEST_PACKAGE_ID}::alpha_lending::${isSuiConversion ? "collect_reward" : "collect_reward_and_deposit"}`,
           typeArguments: [coinType],
           arguments: [
             tx.object(this.constants.LENDING_PROTOCOL_ID),
@@ -1476,10 +1571,26 @@ export class AlphalendClient {
         // Handle promise and add coins to map
         if (promise) {
           const coin2 = await this.handlePromise(tx, promise, coinType);
-          if (coin2) addCoinToMap(coinType, coin2);
+          if (coin2) {
+            if (isSuiConversion) suiCoins.push(coin2);
+            else addCoinToMap(coinType, coin2);
+          }
         }
-        if (coin1) addCoinToMap(coinType, coin1);
+        if (coin1) {
+          if (isSuiConversion) suiCoins.push(coin1);
+          else addCoinToMap(coinType, coin1);
+        }
       }
+    }
+
+    // Stake claimed SUI into stSUI and process it under the stSUI coin type
+    if (suiCoins.length > 0) {
+      const mergedSui = this.mergeCoins(tx, undefined, suiCoins);
+      const stsuiCoin = this.mintStsui(tx, mergedSui);
+      addCoinToMap(
+        normalizeCoinType(this.constants.STSUI_COIN_TYPE),
+        stsuiCoin,
+      );
     }
 
     // Function to supply coin to market or transfer to wallet

--- a/src/models/lendingProtocol.ts
+++ b/src/models/lendingProtocol.ts
@@ -12,6 +12,7 @@ import { Network } from "../constants/index.js";
 export class LendingProtocol {
   private blockchain: Blockchain;
   private coinMetadataMap: Map<string, CoinMetadata>;
+  private network: Network;
 
   /**
    * @param network   One of the supported Sui networks.
@@ -20,6 +21,7 @@ export class LendingProtocol {
   constructor(network: Network, graphqlUrl?: string) {
     this.blockchain = new Blockchain(network, graphqlUrl);
     this.coinMetadataMap = new Map();
+    this.network = network;
   }
 
   /**
@@ -80,18 +82,18 @@ export class LendingProtocol {
   async getPositionFromPositionCapId(positionCapId: string): Promise<Position> {
     const position =
       await this.blockchain.getPositionFromPositionCapId(positionCapId);
-    return new Position(position, this.coinMetadataMap);
+    return new Position(position, this.coinMetadataMap, this.network);
   }
 
   async getPosition(positionId: string): Promise<Position> {
     const position = await this.blockchain.getPosition(positionId);
-    return new Position(position, this.coinMetadataMap);
+    return new Position(position, this.coinMetadataMap, this.network);
   }
 
   async getPositions(userAddress: string): Promise<Position[]> {
     const positions = await this.blockchain.getPositionsForUser(userAddress);
     return positions.map(
-      (position) => new Position(position, this.coinMetadataMap),
+      (position) => new Position(position, this.coinMetadataMap, this.network),
     );
   }
 

--- a/src/models/lendingProtocol.ts
+++ b/src/models/lendingProtocol.ts
@@ -12,7 +12,6 @@ import { Network } from "../constants/index.js";
 export class LendingProtocol {
   private blockchain: Blockchain;
   private coinMetadataMap: Map<string, CoinMetadata>;
-  private network: Network;
 
   /**
    * @param network   One of the supported Sui networks.
@@ -21,7 +20,6 @@ export class LendingProtocol {
   constructor(network: Network, graphqlUrl?: string) {
     this.blockchain = new Blockchain(network, graphqlUrl);
     this.coinMetadataMap = new Map();
-    this.network = network;
   }
 
   /**
@@ -82,18 +80,18 @@ export class LendingProtocol {
   async getPositionFromPositionCapId(positionCapId: string): Promise<Position> {
     const position =
       await this.blockchain.getPositionFromPositionCapId(positionCapId);
-    return new Position(position, this.coinMetadataMap, this.network);
+    return new Position(position, this.coinMetadataMap);
   }
 
   async getPosition(positionId: string): Promise<Position> {
     const position = await this.blockchain.getPosition(positionId);
-    return new Position(position, this.coinMetadataMap, this.network);
+    return new Position(position, this.coinMetadataMap);
   }
 
   async getPositions(userAddress: string): Promise<Position[]> {
     const positions = await this.blockchain.getPositionsForUser(userAddress);
     return positions.map(
-      (position) => new Position(position, this.coinMetadataMap, this.network),
+      (position) => new Position(position, this.coinMetadataMap),
     );
   }
 

--- a/src/models/position.ts
+++ b/src/models/position.ts
@@ -6,17 +6,22 @@ import {
 } from "../utils/parsedTypes.js";
 import { Decimal } from "decimal.js";
 import { Market } from "./market.js";
+import { getConstants, Network } from "../constants/index.js";
+import { normalizeCoinType } from "../utils/parser.js";
 
 export class Position {
   position: PositionType;
   private coinMetadataMap: Map<string, CoinMetadata>;
+  private network?: Network;
 
   constructor(
     position: PositionType,
     coinMetadataMap: Map<string, CoinMetadata>,
+    network?: Network,
   ) {
     this.position = position;
     this.coinMetadataMap = coinMetadataMap;
+    this.network = network;
   }
 
   /**
@@ -151,6 +156,43 @@ export class Position {
       : new Decimal(0);
 
     const rewardsToClaim = this.calculateRewardsToClaim();
+
+    // TEMP: report SUI rewards as stSUI, converted via the SUI/stSUI price
+    // ratio (mirrors alphalend-sdk-rust#212). Runs before the USD total below
+    // so it stays consistent.
+    if (this.network === "mainnet") {
+      const constants = getConstants(this.network);
+      const suiIdx = rewardsToClaim.findIndex(
+        (reward) =>
+          normalizeCoinType(reward.coinType) === constants.SUI_COIN_TYPE,
+      );
+      if (suiIdx !== -1) {
+        const suiReward = rewardsToClaim[suiIdx];
+        const suiPrice = this.getPrice(suiReward.coinType);
+        const stsuiPrice = this.getPrice(constants.STSUI_COIN_TYPE);
+        if (suiPrice.lte(0) || stsuiPrice.lte(0)) {
+          throw new Error(
+            "Missing SUI or stSUI price for SUI -> stSUI reward conversion",
+          );
+        }
+        const stsuiAmount = suiReward.rewardAmount
+          .mul(suiPrice)
+          .div(stsuiPrice);
+        rewardsToClaim.splice(suiIdx, 1);
+        const stsuiReward = rewardsToClaim.find(
+          (reward) =>
+            normalizeCoinType(reward.coinType) === constants.STSUI_COIN_TYPE,
+        );
+        if (stsuiReward) {
+          stsuiReward.rewardAmount = stsuiReward.rewardAmount.add(stsuiAmount);
+        } else {
+          rewardsToClaim.push({
+            coinType: constants.STSUI_COIN_TYPE,
+            rewardAmount: stsuiAmount,
+          });
+        }
+      }
+    }
 
     const rewardsToClaimUsd = rewardsToClaim.reduce((acc, reward) => {
       const price = this.getPrice(reward.coinType);

--- a/src/models/position.ts
+++ b/src/models/position.ts
@@ -6,22 +6,19 @@ import {
 } from "../utils/parsedTypes.js";
 import { Decimal } from "decimal.js";
 import { Market } from "./market.js";
-import { getConstants, Network } from "../constants/index.js";
+import { getConstants } from "../constants/index.js";
 import { normalizeCoinType } from "../utils/parser.js";
 
 export class Position {
   position: PositionType;
   private coinMetadataMap: Map<string, CoinMetadata>;
-  private network?: Network;
 
   constructor(
     position: PositionType,
     coinMetadataMap: Map<string, CoinMetadata>,
-    network?: Network,
   ) {
     this.position = position;
     this.coinMetadataMap = coinMetadataMap;
-    this.network = network;
   }
 
   /**
@@ -160,37 +157,33 @@ export class Position {
     // TEMP: report SUI rewards as stSUI, converted via the SUI/stSUI price
     // ratio (mirrors alphalend-sdk-rust#212). Runs before the USD total below
     // so it stays consistent.
-    if (this.network === "mainnet") {
-      const constants = getConstants(this.network);
-      const suiIdx = rewardsToClaim.findIndex(
-        (reward) =>
-          normalizeCoinType(reward.coinType) === constants.SUI_COIN_TYPE,
-      );
-      if (suiIdx !== -1) {
-        const suiReward = rewardsToClaim[suiIdx];
-        const suiPrice = this.getPrice(suiReward.coinType);
-        const stsuiPrice = this.getPrice(constants.STSUI_COIN_TYPE);
-        if (suiPrice.lte(0) || stsuiPrice.lte(0)) {
-          throw new Error(
-            "Missing SUI or stSUI price for SUI -> stSUI reward conversion",
-          );
-        }
-        const stsuiAmount = suiReward.rewardAmount
-          .mul(suiPrice)
-          .div(stsuiPrice);
-        rewardsToClaim.splice(suiIdx, 1);
-        const stsuiReward = rewardsToClaim.find(
-          (reward) =>
-            normalizeCoinType(reward.coinType) === constants.STSUI_COIN_TYPE,
+    const constants = getConstants("mainnet");
+    const suiIdx = rewardsToClaim.findIndex(
+      (reward) =>
+        normalizeCoinType(reward.coinType) === constants.SUI_COIN_TYPE,
+    );
+    if (suiIdx !== -1) {
+      const suiReward = rewardsToClaim[suiIdx];
+      const suiPrice = this.getPrice(suiReward.coinType);
+      const stsuiPrice = this.getPrice(constants.STSUI_COIN_TYPE);
+      if (suiPrice.lte(0) || stsuiPrice.lte(0)) {
+        throw new Error(
+          "Missing SUI or stSUI price for SUI -> stSUI reward conversion",
         );
-        if (stsuiReward) {
-          stsuiReward.rewardAmount = stsuiReward.rewardAmount.add(stsuiAmount);
-        } else {
-          rewardsToClaim.push({
-            coinType: constants.STSUI_COIN_TYPE,
-            rewardAmount: stsuiAmount,
-          });
-        }
+      }
+      const stsuiAmount = suiReward.rewardAmount.mul(suiPrice).div(stsuiPrice);
+      rewardsToClaim.splice(suiIdx, 1);
+      const stsuiReward = rewardsToClaim.find(
+        (reward) =>
+          normalizeCoinType(reward.coinType) === constants.STSUI_COIN_TYPE,
+      );
+      if (stsuiReward) {
+        stsuiReward.rewardAmount = stsuiReward.rewardAmount.add(stsuiAmount);
+      } else {
+        rewardsToClaim.push({
+          coinType: constants.STSUI_COIN_TYPE,
+          rewardAmount: stsuiAmount,
+        });
       }
     }
 

--- a/src/utils/helper.ts
+++ b/src/utils/helper.ts
@@ -3,6 +3,7 @@ import { getAlphafiConstants, getConstants } from "../constants/index.js";
 import { Receipt, ReceiptGql } from "./queryTypes.js";
 import { getUserPosition } from "../models/position/functions.js";
 import { Blockchain } from "../models/blockchain.js";
+import { normalizeCoinType } from "./parser.js";
 import {
   MarketType,
   RewardDistributorType,
@@ -14,19 +15,26 @@ import {
  * Determine which rewards are claimable for the user, grouped by market id.
  * Uses parsed `PositionType` and `MarketType` (GraphQL-backed) — no raw
  * JSON-RPC shapes are consumed.
+ *
+ * `claimableAmounts` maps normalized coin type -> estimated claimable amount
+ * in raw base units. The estimate mirrors the position refresh math but skips
+ * the market-side time accrual, so it can only understate the true amount.
  */
 export async function getClaimRewardInput(
   blockchain: Blockchain,
   userAddress: string,
   positionCapId?: string,
-): Promise<{ marketId: number; coinTypes: string[] }[]> {
+): Promise<{
+  rewardInput: { marketId: number; coinTypes: string[] }[];
+  claimableAmounts: Map<string, bigint>;
+}> {
   // When a specific positionCapId is provided, resolve the reward input from
   // that exact position rather than the user's first cap. Otherwise fall back
   // to the address-based lookup (first position cap).
   const position = positionCapId
     ? await blockchain.getPositionFromPositionCapId(positionCapId)
     : await getUserPosition(blockchain, userAddress);
-  if (!position) return [];
+  if (!position) return { rewardInput: [], claimableAmounts: new Map() };
 
   // Fetch every distinct market referenced by the position's reward
   // distributors ONCE and in parallel. The previous implementation awaited
@@ -54,6 +62,7 @@ export async function getClaimRewardInput(
 
   const rewardInput: { marketId: number; coinTypes: string[] }[] = [];
   const marketActionMap: Map<number, string[]> = new Map();
+  const claimableAmounts: Map<string, bigint> = new Map();
 
   for (const rewardDistributor of position.rewardDistributors) {
     const marketId = Number(rewardDistributor.marketId);
@@ -70,6 +79,7 @@ export async function getClaimRewardInput(
       rewardDistributor,
       marketRewardDistributor,
       coinTypes,
+      claimableAmounts,
     );
     marketActionMap.set(marketId, [...coinTypes]);
   }
@@ -77,13 +87,14 @@ export async function getClaimRewardInput(
   for (const [marketId, coinTypes] of marketActionMap.entries()) {
     rewardInput.push({ marketId, coinTypes });
   }
-  return rewardInput;
+  return { rewardInput, claimableAmounts };
 }
 
 function addClaimableCoinTypes(
   userDistributor: UserRewardDistributorType,
   marketDistributor: RewardDistributorType,
   coinTypes: Set<string>,
+  claimableAmounts: Map<string, bigint>,
 ): void {
   const lastUpdated = parseFloat(userDistributor.lastUpdated);
   const share = parseFloat(userDistributor.share);
@@ -93,6 +104,32 @@ function addClaimableCoinTypes(
     if (!marketReward) continue;
     const userReward: UserRewardType | null =
       i < userDistributor.rewards.length ? userDistributor.rewards[i] : null;
+
+    // Estimate pending rewards with the same math as Position's
+    // refreshUserRewardDistributor, minus the market-side time accrual
+    // (market cummulativeRewardsPerShare is used as fetched), so the
+    // estimate never overstates the on-chain claim.
+    let pending = 0n;
+    if (userReward) {
+      pending =
+        BigInt(userReward.earnedRewards) +
+        ((BigInt(marketReward.cummulativeRewardsPerShare) -
+          BigInt(userReward.cummulativeRewardsPerShare)) *
+          BigInt(userDistributor.share)) /
+          BigInt(10 ** 18);
+    } else if (lastUpdated <= parseFloat(marketReward.startTime)) {
+      pending =
+        (BigInt(marketReward.cummulativeRewardsPerShare) *
+          BigInt(userDistributor.share)) /
+        BigInt(10 ** 18);
+    }
+    if (pending > 0n) {
+      const coinType = normalizeCoinType(marketReward.coinType);
+      claimableAmounts.set(
+        coinType,
+        (claimableAmounts.get(coinType) ?? 0n) + pending,
+      );
+    }
 
     const timeElapsed =
       Math.min(parseFloat(marketReward.endTime), Date.now()) -

--- a/src/utils/helper.ts
+++ b/src/utils/helper.ts
@@ -117,7 +117,7 @@ function addClaimableCoinTypes(
           BigInt(userReward.cummulativeRewardsPerShare)) *
           BigInt(userDistributor.share)) /
           BigInt(10 ** 18);
-    } else if (lastUpdated <= parseFloat(marketReward.startTime)) {
+    } else {
       pending =
         (BigInt(marketReward.cummulativeRewardsPerShare) *
           BigInt(userDistributor.share)) /


### PR DESCRIPTION
On mainnet, SUI rewards in `claimRewards` and `claimAndSupplyOrRepay` are now staked via `liquid_staking::mint` and the stSUI is transferred/supplied/repaid instead. Estimated SUI rewards below 3 mists keep plain SUI handling (mint aborts with `EZeroLstMinted` on dust).

`getUserPortfolio` reports SUI rewards as stSUI via the SUI/stSUI price ratio, merged into the stSUI entry (mirrors alphalend-sdk-rust#212); throws if either price is missing.

Note: `claimAndSupplyOrRepay` callers must key `borrowedCoins`/`supplyMarkets` on the stSUI coin type for SUI rewards to be repaid/supplied.