### PR TITLE
Add coin object count and merge coins helpers

### DIFF
--- a/src/core/coinHelpers.ts
+++ b/src/core/coinHelpers.ts
@@ -1,0 +1,254 @@
+/**
+ * Standalone coin-management helpers (not lending related).
+ *
+ * Used by admin tooling to inspect an address's coin objects and build
+ * transactions that consolidate them into a single coin object or into the
+ * address balance (accumulator).
+ */
+
+import { Transaction } from "@mysten/sui/transactions";
+import { graphql } from "@mysten/sui/graphql/schema";
+import { normalizeStructTag, SUI_TYPE_ARG } from "@mysten/sui/utils";
+
+import { Network } from "../constants/index.js";
+import { Blockchain } from "../models/blockchain.js";
+
+export type MergeCoinsOutput = "address-balance" | "coin-object";
+
+export interface CoinTypeCount {
+  coinType: string;
+  coinObjectCount: number;
+}
+
+/**
+ * Max coin objects consolidated per transaction. Keeps a single `mergeCoins`
+ * command under the 512-arguments-per-command protocol limit and `send_funds`
+ * command counts under the 1024-commands limit. Callers with more coin
+ * objects re-run the merge until one remains.
+ */
+const MAX_COINS_PER_TX = 500;
+
+interface CoinObjectRef {
+  objectId: string;
+  version: number;
+  digest: string;
+  balance: bigint;
+}
+
+/**
+ * List every coin type held as coin objects by `address`, with the number of
+ * `Coin<T>` objects per type. Coins held purely in the address balance
+ * (accumulator, zero coin objects) do not appear.
+ */
+export async function getCoinObjectCounts(
+  address: string,
+  network: Network,
+): Promise<CoinTypeCount[]> {
+  const blockchain = new Blockchain(network);
+  const query = graphql(`
+    query getOwnedCoinTypes($owner: SuiAddress!, $cursor: String) {
+      address(address: $owner) {
+        objects(filter: { type: "0x2::coin::Coin" }, after: $cursor) {
+          pageInfo {
+            hasNextPage
+            endCursor
+          }
+          nodes {
+            contents {
+              type {
+                repr
+              }
+            }
+          }
+        }
+      }
+    }
+  `);
+
+  const counts = new Map<string, number>();
+  let cursor: string | null = null;
+  let hasMore = true;
+  while (hasMore) {
+    const variables: { owner: string; cursor: string | null } = {
+      owner: address,
+      cursor,
+    };
+    const response = await blockchain.gqlClient.query({ query, variables });
+    const conn = response.data?.address?.objects;
+    for (const node of conn?.nodes ?? []) {
+      const repr = node?.contents?.type?.repr;
+      if (!repr) continue;
+      // repr is `0x…2::coin::Coin<T>`; extract the inner type T
+      const coinType = repr.slice(repr.indexOf("<") + 1, -1);
+      counts.set(coinType, (counts.get(coinType) ?? 0) + 1);
+    }
+    if (conn?.pageInfo?.hasNextPage && conn.pageInfo.endCursor) {
+      cursor = conn.pageInfo.endCursor;
+    } else {
+      hasMore = false;
+    }
+  }
+
+  return [...counts.entries()]
+    .map(([coinType, coinObjectCount]) => ({ coinType, coinObjectCount }))
+    .sort((a, b) => b.coinObjectCount - a.coinObjectCount);
+}
+
+/**
+ * Build a transaction that consolidates all `Coin<coinType>` objects owned by
+ * `address` into a single coin object or into the address balance
+ * (accumulator). Funds already in the address balance are left untouched.
+ *
+ * The sender (and gas payer) is `address` itself. For SUI the largest coin is
+ * set as the gas payment: with `coin-object` output the remaining coins merge
+ * into the gas coin, and with `address-balance` output the remaining coins
+ * are sent to the address balance while the gas coin stays as a coin object.
+ *
+ * At most {@link MAX_COINS_PER_TX} coin objects (largest first) are
+ * consolidated per transaction — re-run until one coin object remains.
+ */
+export async function buildMergeCoinsTransaction(
+  coinType: string,
+  output: MergeCoinsOutput,
+  address: string,
+  network: Network,
+): Promise<Transaction> {
+  const blockchain = new Blockchain(network);
+  const normalizedCoinType = normalizeStructTag(coinType);
+  const isSui = normalizedCoinType === normalizeStructTag(SUI_TYPE_ARG);
+
+  const coins = (
+    await getCoinObjects(blockchain, address, normalizedCoinType)
+  ).sort((a, b) =>
+    a.balance > b.balance ? -1 : a.balance < b.balance ? 1 : 0,
+  );
+  const selected = coins.slice(0, MAX_COINS_PER_TX);
+
+  const tx = new Transaction();
+  tx.setSender(address);
+
+  if (isSui) {
+    const [gasCoin, ...rest] = selected;
+    if (rest === undefined || rest.length === 0) {
+      throw new Error(
+        `Nothing to merge: ${address} holds ${selected.length} SUI coin object(s) and one must remain as the gas coin`,
+      );
+    }
+    tx.setGasPayment([
+      {
+        objectId: gasCoin.objectId,
+        version: gasCoin.version,
+        digest: gasCoin.digest,
+      },
+    ]);
+    if (output === "coin-object") {
+      tx.mergeCoins(
+        tx.gas,
+        rest.map((c) => tx.object(c.objectId)),
+      );
+    } else {
+      for (const coin of rest) {
+        blockchain.sendCoinToAddressBalance(
+          tx,
+          normalizedCoinType,
+          address,
+          coin.objectId,
+        );
+      }
+    }
+    return tx;
+  }
+
+  if (output === "coin-object") {
+    if (selected.length < 2) {
+      throw new Error(
+        `Nothing to merge: ${address} holds ${selected.length} coin object(s) of ${normalizedCoinType}`,
+      );
+    }
+    const [target, ...rest] = selected;
+    tx.mergeCoins(
+      tx.object(target.objectId),
+      rest.map((c) => tx.object(c.objectId)),
+    );
+  } else {
+    if (selected.length === 0) {
+      throw new Error(
+        `Nothing to merge: ${address} holds no coin objects of ${normalizedCoinType}`,
+      );
+    }
+    for (const coin of selected) {
+      blockchain.sendCoinToAddressBalance(
+        tx,
+        normalizedCoinType,
+        address,
+        coin.objectId,
+      );
+    }
+  }
+  return tx;
+}
+
+/**
+ * Paginated fetch of all `Coin<coinType>` objects owned by `owner`, with the
+ * object refs needed for gas payment and the balance for largest-first
+ * ordering.
+ */
+async function getCoinObjects(
+  blockchain: Blockchain,
+  owner: string,
+  coinType: string,
+): Promise<CoinObjectRef[]> {
+  const query = graphql(`
+    query getCoinObjectsOfType(
+      $owner: SuiAddress!
+      $type: String!
+      $cursor: String
+    ) {
+      address(address: $owner) {
+        objects(filter: { type: $type }, after: $cursor) {
+          pageInfo {
+            hasNextPage
+            endCursor
+          }
+          nodes {
+            address
+            version
+            digest
+            contents {
+              json
+            }
+          }
+        }
+      }
+    }
+  `);
+
+  const out: CoinObjectRef[] = [];
+  let cursor: string | null = null;
+  let hasMore = true;
+  while (hasMore) {
+    const variables: { owner: string; type: string; cursor: string | null } = {
+      owner,
+      type: `0x2::coin::Coin<${coinType}>`,
+      cursor,
+    };
+    const response = await blockchain.gqlClient.query({ query, variables });
+    const conn = response.data?.address?.objects;
+    for (const node of conn?.nodes ?? []) {
+      if (!node?.address || node.version == null || !node.digest) continue;
+      const json = node.contents?.json as { balance?: string } | undefined;
+      out.push({
+        objectId: node.address,
+        version: node.version,
+        digest: node.digest,
+        balance: BigInt(json?.balance ?? 0),
+      });
+    }
+    if (conn?.pageInfo?.hasNextPage && conn.pageInfo.endCursor) {
+      cursor = conn.pageInfo.endCursor;
+    } else {
+      hasMore = false;
+    }
+  }
+  return out;
+}

--- a/src/core/coinHelpers.ts
+++ b/src/core/coinHelpers.ts
@@ -31,6 +31,13 @@ export interface CoinTypeCount {
  */
 const MAX_COINS_PER_TX = 500;
 
+/**
+ * Min SUI address balance (in MIST) for paying gas from the address balance
+ * instead of reserving a gas coin. 0.1 SUI — well above observed resolved
+ * budgets for full send_funds transactions (~0.0002 SUI for 20 sends).
+ */
+const MIN_ADDRESS_BALANCE_FOR_GAS = 100_000_000n;
+
 interface CoinObjectRef {
   objectId: string;
   version: number;
@@ -77,6 +84,12 @@ export async function getCoinObjectCounts(
  * coin is one. The largest SUI coin is reserved as the gas coin (it alone
  * must cover the gas budget): with `coin-object` output everything merges
  * into it, and with `address-balance` output it stays as a coin object.
+ * Exception: with `address-balance` output, when the pre-existing SUI address
+ * balance already exceeds {@link MIN_ADDRESS_BALANCE_FOR_GAS} no gas coin is
+ * reserved — gas resolves against the address balance and every coin is sent,
+ * leaving none behind. (Funds deposited by this same transaction cannot pay
+ * its gas, so a first run that leaves the gas coin can be re-run once the
+ * address balance is funded.)
  *
  * Consolidates at most {@link MAX_COINS_PER_TX} coin objects per transaction
  * — re-run until one coin object remains.
@@ -91,34 +104,54 @@ export async function buildMergeCoinsTransaction(
   const normalizedCoinType = normalizeStructTag(coinType);
   const isSui = normalizedCoinType === normalizeStructTag(SUI_TYPE_ARG);
 
+  const addressBalance =
+    output === "coin-object" || isSui
+      ? await getAddressBalance(blockchain, address, normalizedCoinType)
+      : 0n;
+  // With enough pre-existing SUI address balance, gas resolves against it
+  // instead of a reserved gas coin, so every coin object can be sent
+  const useAddressBalanceGas =
+    isSui &&
+    output === "address-balance" &&
+    addressBalance >= MIN_ADDRESS_BALANCE_FOR_GAS;
+
   // Balances are only needed to pick a gas coin that can cover the budget
-  const withBalance = isSui;
+  const withBalance = isSui && !useAddressBalanceGas;
   const coins = await getCoinObjects(
     blockchain,
     address,
     normalizedCoinType,
     withBalance,
   );
-  const addressBalance =
-    output === "coin-object"
-      ? await getAddressBalance(blockchain, address, normalizedCoinType)
-      : 0n;
 
   const tx = new Transaction();
   tx.setSender(address);
 
   if (isSui) {
     if (coins.length === 0) {
-      throw new Error(
-        `Nothing to merge: ${address} holds no SUI coin objects (one is needed as the gas coin)`,
-      );
+      throw new Error(`Nothing to merge: ${address} holds no SUI coin objects`);
+    }
+    if (useAddressBalanceGas) {
+      for (const coin of coins.slice(0, MAX_COINS_PER_TX)) {
+        blockchain.sendCoinToAddressBalance(
+          tx,
+          normalizedCoinType,
+          address,
+          coin.objectId,
+        );
+      }
+      return tx;
     }
     // The reserved gas coin alone must cover the budget, so use the largest
     const gasCoin = coins.reduce((a, b) =>
       (b.balance ?? 0n) > (a.balance ?? 0n) ? b : a,
     );
     const rest = coins.filter((c) => c !== gasCoin).slice(0, MAX_COINS_PER_TX);
-    if (rest.length === 0 && addressBalance === 0n) {
+    // For coin-object output a nonzero address balance is still work (it gets
+    // withdrawn into the gas coin); for address-balance output it is not
+    const hasWork =
+      rest.length > 0 || (output === "coin-object" && addressBalance > 0n);
+    if (!hasWork) {
       throw new Error(
         output === "coin-object"
           ? `Nothing to merge: ${address} holds a single SUI coin object and no address balance`

--- a/src/core/coinHelpers.ts
+++ b/src/core/coinHelpers.ts
@@ -36,7 +36,7 @@ interface CoinObjectRef {
   version: number;
   digest: string;
   coinType: string;
-  balance: bigint;
+  balance?: bigint;
 }
 
 /**
@@ -71,13 +71,15 @@ export async function getCoinObjectCounts(
  * `address-balance` output the coin objects are sent to the address balance
  * via `0x2::coin::send_funds`.
  *
- * The sender (and gas payer) is `address` itself. For SUI the largest coin is
- * set as the gas payment (it must cover the gas budget): with `coin-object`
- * output everything merges into the gas coin, and with `address-balance`
- * output the gas coin stays as a coin object.
+ * The sender (and gas payer) is `address` itself. Gas payment must be set
+ * explicitly for SUI because the automatic build-time gas resolution can only
+ * pick SUI coins that are not inputs of the transaction, and here every SUI
+ * coin is one. The largest SUI coin is reserved as the gas coin (it alone
+ * must cover the gas budget): with `coin-object` output everything merges
+ * into it, and with `address-balance` output it stays as a coin object.
  *
- * At most {@link MAX_COINS_PER_TX} coin objects are consolidated per
- * transaction — re-run until one coin object remains.
+ * Consolidates at most {@link MAX_COINS_PER_TX} coin objects per transaction
+ * — re-run until one coin object remains.
  */
 export async function buildMergeCoinsTransaction(
   coinType: string,
@@ -89,8 +91,14 @@ export async function buildMergeCoinsTransaction(
   const normalizedCoinType = normalizeStructTag(coinType);
   const isSui = normalizedCoinType === normalizeStructTag(SUI_TYPE_ARG);
 
-  const coins = await getCoinObjects(blockchain, address, normalizedCoinType);
-  const selected = coins.slice(0, MAX_COINS_PER_TX);
+  // Balances are only needed to pick a gas coin that can cover the budget
+  const withBalance = isSui;
+  const coins = await getCoinObjects(
+    blockchain,
+    address,
+    normalizedCoinType,
+    withBalance,
+  );
   const addressBalance =
     output === "coin-object"
       ? await getAddressBalance(blockchain, address, normalizedCoinType)
@@ -100,14 +108,16 @@ export async function buildMergeCoinsTransaction(
   tx.setSender(address);
 
   if (isSui) {
-    if (selected.length === 0) {
+    if (coins.length === 0) {
       throw new Error(
         `Nothing to merge: ${address} holds no SUI coin objects (one is needed as the gas coin)`,
       );
     }
-    // The gas coin must cover the gas budget, so use the largest coin
-    const gasCoin = selected.reduce((a, b) => (b.balance > a.balance ? b : a));
-    const rest = selected.filter((c) => c !== gasCoin);
+    // The reserved gas coin alone must cover the budget, so use the largest
+    const gasCoin = coins.reduce((a, b) =>
+      (b.balance ?? 0n) > (a.balance ?? 0n) ? b : a,
+    );
+    const rest = coins.filter((c) => c !== gasCoin).slice(0, MAX_COINS_PER_TX);
     if (rest.length === 0 && addressBalance === 0n) {
       throw new Error(
         output === "coin-object"
@@ -147,6 +157,7 @@ export async function buildMergeCoinsTransaction(
     return tx;
   }
 
+  const selected = coins.slice(0, MAX_COINS_PER_TX);
   if (output === "coin-object") {
     if (selected.length <= 1 && addressBalance === 0n) {
       throw new Error(
@@ -231,18 +242,21 @@ async function getAddressBalance(
 /**
  * Paginated fetch of the `Coin<coinType>` objects owned by `owner` (all coin
  * objects when `coinType` is omitted), with the object refs needed for gas
- * payment and the balance used to pick the SUI gas coin.
+ * payment. Coin balances are only fetched when `withBalance` is set (used to
+ * pick a SUI gas coin).
  */
 async function getCoinObjects(
   blockchain: Blockchain,
   owner: string,
   coinType?: string,
+  withBalance = false,
 ): Promise<CoinObjectRef[]> {
   const query = graphql(`
     query getCoinObjectsOfType(
       $owner: SuiAddress!
       $type: String!
       $cursor: String
+      $withBalance: Boolean = false
     ) {
       address(address: $owner) {
         objects(filter: { type: $type }, after: $cursor) {
@@ -258,7 +272,7 @@ async function getCoinObjects(
               type {
                 repr
               }
-              json
+              json @include(if: $withBalance)
             }
           }
         }
@@ -270,10 +284,16 @@ async function getCoinObjects(
   let cursor: string | null = null;
   let hasMore = true;
   while (hasMore) {
-    const variables: { owner: string; type: string; cursor: string | null } = {
+    const variables: {
+      owner: string;
+      type: string;
+      cursor: string | null;
+      withBalance: boolean;
+    } = {
       owner,
       type: coinType ? `0x2::coin::Coin<${coinType}>` : "0x2::coin::Coin",
       cursor,
+      withBalance,
     };
     const response = await blockchain.gqlClient.query({ query, variables });
     const conn = response.data?.address?.objects;
@@ -289,7 +309,7 @@ async function getCoinObjects(
         digest: node.digest,
         // repr is `0x…2::coin::Coin<T>`; extract the inner type T
         coinType: repr.slice(repr.indexOf("<") + 1, -1),
-        balance: BigInt(json?.balance ?? 0),
+        ...(withBalance ? { balance: BigInt(json?.balance ?? 0) } : {}),
       });
     }
     if (conn?.pageInfo?.hasNextPage && conn.pageInfo.endCursor) {

--- a/src/core/coinHelpers.ts
+++ b/src/core/coinHelpers.ts
@@ -6,7 +6,10 @@
  * address balance (accumulator).
  */
 
-import { Transaction } from "@mysten/sui/transactions";
+import {
+  Transaction,
+  TransactionObjectArgument,
+} from "@mysten/sui/transactions";
 import { graphql } from "@mysten/sui/graphql/schema";
 import { normalizeStructTag, SUI_TYPE_ARG } from "@mysten/sui/utils";
 
@@ -32,6 +35,7 @@ interface CoinObjectRef {
   objectId: string;
   version: number;
   digest: string;
+  coinType: string;
   balance: bigint;
 }
 
@@ -45,48 +49,11 @@ export async function getCoinObjectCounts(
   network: Network,
 ): Promise<CoinTypeCount[]> {
   const blockchain = new Blockchain(network);
-  const query = graphql(`
-    query getOwnedCoinTypes($owner: SuiAddress!, $cursor: String) {
-      address(address: $owner) {
-        objects(filter: { type: "0x2::coin::Coin" }, after: $cursor) {
-          pageInfo {
-            hasNextPage
-            endCursor
-          }
-          nodes {
-            contents {
-              type {
-                repr
-              }
-            }
-          }
-        }
-      }
-    }
-  `);
+  const coins = await getCoinObjects(blockchain, address);
 
   const counts = new Map<string, number>();
-  let cursor: string | null = null;
-  let hasMore = true;
-  while (hasMore) {
-    const variables: { owner: string; cursor: string | null } = {
-      owner: address,
-      cursor,
-    };
-    const response = await blockchain.gqlClient.query({ query, variables });
-    const conn = response.data?.address?.objects;
-    for (const node of conn?.nodes ?? []) {
-      const repr = node?.contents?.type?.repr;
-      if (!repr) continue;
-      // repr is `0x…2::coin::Coin<T>`; extract the inner type T
-      const coinType = repr.slice(repr.indexOf("<") + 1, -1);
-      counts.set(coinType, (counts.get(coinType) ?? 0) + 1);
-    }
-    if (conn?.pageInfo?.hasNextPage && conn.pageInfo.endCursor) {
-      cursor = conn.pageInfo.endCursor;
-    } else {
-      hasMore = false;
-    }
+  for (const coin of coins) {
+    counts.set(coin.coinType, (counts.get(coin.coinType) ?? 0) + 1);
   }
 
   return [...counts.entries()]
@@ -97,15 +64,20 @@ export async function getCoinObjectCounts(
 /**
  * Build a transaction that consolidates all `Coin<coinType>` objects owned by
  * `address` into a single coin object or into the address balance
- * (accumulator). Funds already in the address balance are left untouched.
+ * (accumulator).
+ *
+ * With `coin-object` output any existing address balance is also withdrawn
+ * and merged in, so the full balance ends up in one coin object. With
+ * `address-balance` output the coin objects are sent to the address balance
+ * via `0x2::coin::send_funds`.
  *
  * The sender (and gas payer) is `address` itself. For SUI the largest coin is
- * set as the gas payment: with `coin-object` output the remaining coins merge
- * into the gas coin, and with `address-balance` output the remaining coins
- * are sent to the address balance while the gas coin stays as a coin object.
+ * set as the gas payment (it must cover the gas budget): with `coin-object`
+ * output everything merges into the gas coin, and with `address-balance`
+ * output the gas coin stays as a coin object.
  *
- * At most {@link MAX_COINS_PER_TX} coin objects (largest first) are
- * consolidated per transaction — re-run until one coin object remains.
+ * At most {@link MAX_COINS_PER_TX} coin objects are consolidated per
+ * transaction — re-run until one coin object remains.
  */
 export async function buildMergeCoinsTransaction(
   coinType: string,
@@ -117,21 +89,30 @@ export async function buildMergeCoinsTransaction(
   const normalizedCoinType = normalizeStructTag(coinType);
   const isSui = normalizedCoinType === normalizeStructTag(SUI_TYPE_ARG);
 
-  const coins = (
-    await getCoinObjects(blockchain, address, normalizedCoinType)
-  ).sort((a, b) =>
-    a.balance > b.balance ? -1 : a.balance < b.balance ? 1 : 0,
-  );
+  const coins = await getCoinObjects(blockchain, address, normalizedCoinType);
   const selected = coins.slice(0, MAX_COINS_PER_TX);
+  const addressBalance =
+    output === "coin-object"
+      ? await getAddressBalance(blockchain, address, normalizedCoinType)
+      : 0n;
 
   const tx = new Transaction();
   tx.setSender(address);
 
   if (isSui) {
-    const [gasCoin, ...rest] = selected;
-    if (rest === undefined || rest.length === 0) {
+    if (selected.length === 0) {
       throw new Error(
-        `Nothing to merge: ${address} holds ${selected.length} SUI coin object(s) and one must remain as the gas coin`,
+        `Nothing to merge: ${address} holds no SUI coin objects (one is needed as the gas coin)`,
+      );
+    }
+    // The gas coin must cover the gas budget, so use the largest coin
+    const gasCoin = selected.reduce((a, b) => (b.balance > a.balance ? b : a));
+    const rest = selected.filter((c) => c !== gasCoin);
+    if (rest.length === 0 && addressBalance === 0n) {
+      throw new Error(
+        output === "coin-object"
+          ? `Nothing to merge: ${address} holds a single SUI coin object and no address balance`
+          : `Nothing to merge: ${address} holds a single SUI coin object; it must remain as the gas coin`,
       );
     }
     tx.setGasPayment([
@@ -142,10 +123,17 @@ export async function buildMergeCoinsTransaction(
       },
     ]);
     if (output === "coin-object") {
-      tx.mergeCoins(
-        tx.gas,
-        rest.map((c) => tx.object(c.objectId)),
-      );
+      if (rest.length > 0) {
+        tx.mergeCoins(
+          tx.gas,
+          rest.map((c) => tx.object(c.objectId)),
+        );
+      }
+      if (addressBalance > 0n) {
+        tx.mergeCoins(tx.gas, [
+          withdrawAddressBalance(tx, normalizedCoinType, addressBalance),
+        ]);
+      }
     } else {
       for (const coin of rest) {
         blockchain.sendCoinToAddressBalance(
@@ -160,16 +148,25 @@ export async function buildMergeCoinsTransaction(
   }
 
   if (output === "coin-object") {
-    if (selected.length < 2) {
+    if (selected.length <= 1 && addressBalance === 0n) {
       throw new Error(
-        `Nothing to merge: ${address} holds ${selected.length} coin object(s) of ${normalizedCoinType}`,
+        `Nothing to merge: ${address} holds ${selected.length} coin object(s) of ${normalizedCoinType} and no address balance`,
       );
     }
-    const [target, ...rest] = selected;
-    tx.mergeCoins(
-      tx.object(target.objectId),
-      rest.map((c) => tx.object(c.objectId)),
-    );
+    const withdrawnCoin =
+      addressBalance > 0n
+        ? withdrawAddressBalance(tx, normalizedCoinType, addressBalance)
+        : null;
+    if (selected.length === 0) {
+      // No existing coin object to merge into; the withdrawn coin becomes it
+      tx.transferObjects([withdrawnCoin!], address);
+    } else {
+      const [target, ...rest] = selected;
+      tx.mergeCoins(tx.object(target.objectId), [
+        ...rest.map((c) => tx.object(c.objectId)),
+        ...(withdrawnCoin ? [withdrawnCoin] : []),
+      ]);
+    }
   } else {
     if (selected.length === 0) {
       throw new Error(
@@ -189,14 +186,57 @@ export async function buildMergeCoinsTransaction(
 }
 
 /**
- * Paginated fetch of all `Coin<coinType>` objects owned by `owner`, with the
- * object refs needed for gas payment and the balance for largest-first
- * ordering.
+ * Withdraw `amount` of `coinType` from the sender's address balance and
+ * return it as a `Coin<coinType>` argument.
+ */
+function withdrawAddressBalance(
+  tx: Transaction,
+  coinType: string,
+  amount: bigint,
+): TransactionObjectArgument {
+  const balance = tx.moveCall({
+    target: "0x2::balance::redeem_funds",
+    typeArguments: [coinType],
+    arguments: [tx.withdrawal({ amount, type: coinType })],
+  });
+  return tx.moveCall({
+    target: "0x2::coin::from_balance",
+    typeArguments: [coinType],
+    arguments: [balance],
+  });
+}
+
+/** Fetch the address balance (accumulator) of `coinType` held by `owner`. */
+async function getAddressBalance(
+  blockchain: Blockchain,
+  owner: string,
+  coinType: string,
+): Promise<bigint> {
+  const query = graphql(`
+    query getAddressBalance($owner: SuiAddress!, $coinType: String!) {
+      address(address: $owner) {
+        balance(coinType: $coinType) {
+          addressBalance
+        }
+      }
+    }
+  `);
+  const response = await blockchain.gqlClient.query({
+    query,
+    variables: { owner, coinType },
+  });
+  return BigInt(response.data?.address?.balance?.addressBalance ?? 0);
+}
+
+/**
+ * Paginated fetch of the `Coin<coinType>` objects owned by `owner` (all coin
+ * objects when `coinType` is omitted), with the object refs needed for gas
+ * payment and the balance used to pick the SUI gas coin.
  */
 async function getCoinObjects(
   blockchain: Blockchain,
   owner: string,
-  coinType: string,
+  coinType?: string,
 ): Promise<CoinObjectRef[]> {
   const query = graphql(`
     query getCoinObjectsOfType(
@@ -215,6 +255,9 @@ async function getCoinObjects(
             version
             digest
             contents {
+              type {
+                repr
+              }
               json
             }
           }
@@ -229,18 +272,23 @@ async function getCoinObjects(
   while (hasMore) {
     const variables: { owner: string; type: string; cursor: string | null } = {
       owner,
-      type: `0x2::coin::Coin<${coinType}>`,
+      type: coinType ? `0x2::coin::Coin<${coinType}>` : "0x2::coin::Coin",
       cursor,
     };
     const response = await blockchain.gqlClient.query({ query, variables });
     const conn = response.data?.address?.objects;
     for (const node of conn?.nodes ?? []) {
-      if (!node?.address || node.version == null || !node.digest) continue;
+      const repr = node?.contents?.type?.repr;
+      if (!node?.address || node.version == null || !node.digest || !repr) {
+        continue;
+      }
       const json = node.contents?.json as { balance?: string } | undefined;
       out.push({
         objectId: node.address,
         version: node.version,
         digest: node.digest,
+        // repr is `0x…2::coin::Coin<T>`; extract the inner type T
+        coinType: repr.slice(repr.indexOf("<") + 1, -1),
         balance: BigInt(json?.balance ?? 0),
       });
     }

--- a/src/core/coinHelpers.ts
+++ b/src/core/coinHelpers.ts
@@ -93,6 +93,11 @@ export async function getCoinObjectCounts(
  *
  * Consolidates at most {@link MAX_COINS_PER_TX} coin objects per transaction
  * — re-run until one coin object remains.
+ *
+ * The address balance is read at build time and withdrawn as an exact amount
+ * (the protocol does not support entire-balance withdrawals yet), so
+ * concurrent accumulator activity between build and execution fails the
+ * transaction with "Invalid withdraw reservation" — rebuild and retry.
  */
 export async function buildMergeCoinsTransaction(
   coinType: string,
@@ -132,14 +137,12 @@ export async function buildMergeCoinsTransaction(
       throw new Error(`Nothing to merge: ${address} holds no SUI coin objects`);
     }
     if (useAddressBalanceGas) {
-      for (const coin of coins.slice(0, MAX_COINS_PER_TX)) {
-        blockchain.sendCoinToAddressBalance(
-          tx,
-          normalizedCoinType,
-          address,
-          coin.objectId,
-        );
-      }
+      sendCoinsToAddressBalance(
+        tx,
+        normalizedCoinType,
+        address,
+        coins.slice(0, MAX_COINS_PER_TX),
+      );
       return tx;
     }
     // The reserved gas coin alone must cover the budget, so use the largest
@@ -178,14 +181,7 @@ export async function buildMergeCoinsTransaction(
         ]);
       }
     } else {
-      for (const coin of rest) {
-        blockchain.sendCoinToAddressBalance(
-          tx,
-          normalizedCoinType,
-          address,
-          coin.objectId,
-        );
-      }
+      sendCoinsToAddressBalance(tx, normalizedCoinType, address, rest);
     }
     return tx;
   }
@@ -217,16 +213,30 @@ export async function buildMergeCoinsTransaction(
         `Nothing to merge: ${address} holds no coin objects of ${normalizedCoinType}`,
       );
     }
-    for (const coin of selected) {
-      blockchain.sendCoinToAddressBalance(
-        tx,
-        normalizedCoinType,
-        address,
-        coin.objectId,
-      );
-    }
+    sendCoinsToAddressBalance(tx, normalizedCoinType, address, selected);
   }
   return tx;
+}
+
+/**
+ * `send_funds` each coin into `address`'s address balance, sharing a single
+ * recipient input across all calls (each `tx.pure` call would otherwise add
+ * a duplicate input).
+ */
+function sendCoinsToAddressBalance(
+  tx: Transaction,
+  coinType: string,
+  address: string,
+  coins: CoinObjectRef[],
+) {
+  const recipient = tx.pure.address(address);
+  for (const coin of coins) {
+    tx.moveCall({
+      target: "0x2::coin::send_funds",
+      typeArguments: [coinType],
+      arguments: [tx.object(coin.objectId), recipient],
+    });
+  }
 }
 
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,3 +19,8 @@ export {
   getNaviFlashLoanSupportedCoinTypes,
   getNaviFlashLoanFeeForCoinType,
 } from "./core/flashRepay.js";
+export {
+  getCoinObjectCounts,
+  buildMergeCoinsTransaction,
+} from "./core/coinHelpers.js";
+export type { MergeCoinsOutput, CoinTypeCount } from "./core/coinHelpers.js";


### PR DESCRIPTION
Standalone helpers (not lending related) for admin tooling:

- `getCoinObjectCounts(address, network)` — lists all coin types held as coin objects with per-type counts.
- `buildMergeCoinsTransaction(coinType, output, address, network)` — builds a PTB merging all coin objects of a type into a single coin object or the address balance. With `coin-object` output any existing address balance is also withdrawn (`redeem_funds` + `from_balance`) and merged in. Both functions share one coin-objects GraphQL query. SUI is special-cased (largest coin reserved as gas payment); capped at 500 coins per tx, re-run until one remains.

All merge/withdrawal paths verified via mainnet simulation.