### PR TITLE
fix: project market-side accrual into claimable reward estimate

### DIFF
--- a/src/core/client.ts
+++ b/src/core/client.ts
@@ -1048,8 +1048,8 @@ export class AlphalendClient {
    *
    * On mainnet, SUI rewards are staked into stSUI via `liquid_staking::mint` and
    * the stSUI is transferred to the user (or supplied to the stSUI market when
-   * `claimAndDepositAll` is set). Dust SUI rewards below 0.01 SUI keep the plain
-   * SUI behavior.
+   * `claimAndDepositAll` is set). Estimated SUI rewards below
+   * `MIN_SUI_STAKE_AMOUNT` keep the plain SUI behavior.
    * @returns Transaction object ready for signing and execution
    */
   async claimRewards(params: ClaimRewardsParams): Promise<Transaction> {
@@ -1495,7 +1495,8 @@ export class AlphalendClient {
    *
    * On mainnet, SUI rewards are staked into stSUI via `liquid_staking::mint` and
    * processed as stSUI, so `borrowedCoins`/`supplyMarkets` lookups run against the
-   * stSUI coin type. Dust SUI rewards below 0.01 SUI keep the plain SUI behavior.
+   * stSUI coin type. Estimated SUI rewards below `MIN_SUI_STAKE_AMOUNT` keep
+   * the plain SUI behavior.
    *
    * On mainnet, optionally updates prices first if `priceUpdateCoinTypes` is provided.
    *

--- a/src/utils/helper.ts
+++ b/src/utils/helper.ts
@@ -7,6 +7,7 @@ import { normalizeCoinType } from "./parser.js";
 import {
   MarketType,
   RewardDistributorType,
+  RewardType,
   UserRewardDistributorType,
   UserRewardType,
 } from "./parsedTypes.js";
@@ -17,8 +18,10 @@ import {
  * JSON-RPC shapes are consumed.
  *
  * `claimableAmounts` maps normalized coin type -> estimated claimable amount
- * in raw base units. The estimate mirrors the position refresh math but skips
- * the market-side time accrual, so it can only understate the true amount.
+ * in raw base units. The estimate mirrors the position refresh math, including
+ * a client-side projection of the market-side accrual since the distributor's
+ * last on-chain refresh, so a reward that has accrued but not yet been
+ * checkpointed on-chain still counts toward the estimate.
  */
 export async function getClaimRewardInput(
   blockchain: Blockchain,
@@ -106,22 +109,22 @@ function addClaimableCoinTypes(
       i < userDistributor.rewards.length ? userDistributor.rewards[i] : null;
 
     // Estimate pending rewards with the same math as Position's
-    // refreshUserRewardDistributor, minus the market-side time accrual
-    // (market cummulativeRewardsPerShare is used as fetched), so the
-    // estimate never overstates the on-chain claim.
+    // refreshUserRewardDistributor, projecting the market-side accrual since
+    // the distributor's last on-chain refresh — otherwise a reward campaign
+    // that started after that refresh estimates to zero even though the
+    // on-chain claim will accrue and pay it out.
+    const marketCum =
+      BigInt(marketReward.cummulativeRewardsPerShare) +
+      projectedRewardsPerShare(marketReward, marketDistributor);
     let pending = 0n;
     if (userReward) {
       pending =
         BigInt(userReward.earnedRewards) +
-        ((BigInt(marketReward.cummulativeRewardsPerShare) -
-          BigInt(userReward.cummulativeRewardsPerShare)) *
+        ((marketCum - BigInt(userReward.cummulativeRewardsPerShare)) *
           BigInt(userDistributor.share)) /
           BigInt(10 ** 18);
     } else {
-      pending =
-        (BigInt(marketReward.cummulativeRewardsPerShare) *
-          BigInt(userDistributor.share)) /
-        BigInt(10 ** 18);
+      pending = (marketCum * BigInt(userDistributor.share)) / BigInt(10 ** 18);
     }
     if (pending > 0n) {
       const coinType = normalizeCoinType(marketReward.coinType);
@@ -157,6 +160,32 @@ function addClaimableCoinTypes(
       coinTypes.add(marketReward.coinType);
     }
   }
+}
+
+/**
+ * Rewards-per-share (1e18-scaled) accrued since the distributor's last
+ * on-chain refresh, mirroring Market.refreshRewardDistributors and the
+ * on-chain refresh math.
+ */
+function projectedRewardsPerShare(
+  reward: RewardType,
+  distributor: RewardDistributorType,
+): bigint {
+  const now = Date.now();
+  const lastUpdated = parseInt(distributor.lastUpdated);
+  if (distributor.totalXtokens === "0") return 0n;
+  if (parseInt(reward.startTime) >= now) return 0n;
+  if (parseInt(reward.endTime) <= lastUpdated) return 0n;
+
+  const start = Math.max(lastUpdated, parseInt(reward.startTime));
+  const end = Math.min(now, parseInt(reward.endTime));
+  if (end <= start) return 0n;
+
+  const rewardsGenerated =
+    ((BigInt(reward.totalRewards) - BigInt(reward.distributedRewards)) *
+      BigInt(end - start)) /
+    (BigInt(reward.endTime) - BigInt(lastUpdated));
+  return (rewardsGenerated * BigInt(1e18)) / BigInt(distributor.totalXtokens);
 }
 
 export async function setPrices(tx: Transaction) {


### PR DESCRIPTION
The claimable-amount estimate in `getClaimRewardInput` used the market distributor's `cummulative_rewards_per_share` as fetched, skipping time accrual since the distributor's last on-chain refresh. For a freshly started reward campaign (nothing refreshed the distributor since `startTime`) the estimate came out 0, so `convertSuiToStsui` failed its `MIN_SUI_STAKE_AMOUNT` gate and SUI rewards took the plain `collect_reward_and_deposit` path instead of collect → mint stSUI → supply/repay.

Seen in mainnet tx `CdAKEJRQfdePwYwuxHsQKsfYv9u3BVTHrMm88zEQrX3S`: market 32's SUI campaign started ~17.5 min before the tx, estimate was 0, actual claim was 0.0695 SUI.

Fix: project the market-side accrual client-side with the same formula as `Market.refreshRewardDistributors` and the on-chain refresh, and add it to the fetched counter before computing pending. Replaying the projection against the tx above reproduces the on-chain claim exactly (69496561 mists).

Also corrects two docstrings that claimed the dust threshold was 0.01 SUI (`MIN_SUI_STAKE_AMOUNT` is 3 mists).