### PR TITLE
Fix claim reward flows: swap slippage aborts and stSUI supply

### DIFF
--- a/src/core/cetusSwap.ts
+++ b/src/core/cetusSwap.ts
@@ -35,6 +35,7 @@ export class CetusSwap {
         "METASTABLE",
         "HAEDALHMMV2",
         "HAEDALPMM",
+        "BOLT",
       ]);
 
       const router = await this.client.findRouters({

--- a/src/core/client.ts
+++ b/src/core/client.ts
@@ -1248,7 +1248,7 @@ export class AlphalendClient {
     // ensureInitialized (coin metadata fetch) and getClaimRewardInput (position
     // + market reads) are independent network round-trips, so run them
     // concurrently instead of sequentially.
-    const [, { rewardInput }] = await Promise.all([
+    const [, { rewardInput, claimableAmounts }] = await Promise.all([
       // Ensure SDK is initialized to have access to coin metadata (including prices)
       this.ensureInitialized(),
       // Get all claimable rewards
@@ -1271,9 +1271,16 @@ export class AlphalendClient {
       await this.updatePrices(tx, params.priceUpdateCoinTypes);
     }
 
+    // Prefer the on-chain-derived claimable estimate over params.rewardAmounts:
+    // callers pass display amounts (e.g. SUI rewards folded into stSUI), which
+    // over-quote the swap and trip the aggregator's slippage check.
+    const getRewardAmount = (coinType: string): string | undefined =>
+      claimableAmounts.get(coinType)?.toString() ??
+      params.rewardAmounts?.get(coinType);
+
     // Helper function to calculate USD value for a coin type
     const calculateUsdValue = (coinType: string): number | null => {
-      const rewardAmount = params.rewardAmounts?.get(coinType);
+      const rewardAmount = getRewardAmount(coinType);
       if (!rewardAmount) return 0;
 
       const coinMetadata = this.coinMetadataMap.get(coinType);
@@ -1399,8 +1406,8 @@ export class AlphalendClient {
           targetCoin = mergedCoin;
         }
       } else {
-        // Use provided reward amount for quote, or fallback to 1 token
-        const quoteAmount = params.rewardAmounts?.get(coinType) || "1000000000";
+        // Use estimated claimable amount for quote, or fallback to 1 token
+        const quoteAmount = getRewardAmount(coinType) || "1000000000";
         const router = await this.cetusSwap.getCetusSwapQuote(
           coinType,
           params.targetCoinType,

--- a/src/core/client.ts
+++ b/src/core/client.ts
@@ -1592,13 +1592,11 @@ export class AlphalendClient {
     }
 
     // Stake claimed SUI into stSUI and process it under the stSUI coin type
+    const stsuiCoinType = normalizeCoinType(this.constants.STSUI_COIN_TYPE);
     if (suiCoins.length > 0) {
       const mergedSui = this.mergeCoins(tx, undefined, suiCoins);
       const stsuiCoin = this.mintStsui(tx, mergedSui);
-      addCoinToMap(
-        normalizeCoinType(this.constants.STSUI_COIN_TYPE),
-        stsuiCoin,
-      );
+      addCoinToMap(stsuiCoinType, stsuiCoin);
     }
 
     // Function to supply coin to market or transfer to wallet
@@ -1656,8 +1654,15 @@ export class AlphalendClient {
           remainingCoin,
         );
       } else {
-        // Not borrowed - supply or transfer
-        handleCoin(mergedCoin, coinType, params.supplyMarkets?.get(coinType));
+        // Not borrowed - supply or transfer. stSUI minted from SUI rewards has
+        // no caller-provided supply market; default to the stSUI market so it
+        // is supplied like other rewards (mirrors collect_reward_and_deposit's
+        // on-chain auto-deposit).
+        let supplyInfo = params.supplyMarkets?.get(coinType);
+        if (!supplyInfo && suiCoins.length > 0 && coinType === stsuiCoinType) {
+          supplyInfo = { marketId: String(this.constants.STSUI_MARKET_ID) };
+        }
+        handleCoin(mergedCoin, coinType, supplyInfo);
       }
     }
     return tx;

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -256,7 +256,7 @@ export interface ClaimSwapAndSupplyOrRepayOrTransferParams {
   slippage: number;
   /** Coin types of user's supplied assets (for price updates) */
   priceUpdateCoinTypes: string[];
-  /** Optional map of reward coin types to their amounts in base units (for accurate quotes and USD calculations) */
+  /** Optional map of reward coin types to their amounts in base units; used as fallback when the on-chain claimable estimate is unavailable */
   rewardAmounts?: Map<string, string>;
   /** If true, claims rewards < $0.01 directly to wallet (only swap checkbox case) */
   claimSmallRewardsToWallet?: boolean;


### PR DESCRIPTION
Fixes two issues in the claim reward flows:

- **claimSwapAndSupplyOrRepayOrTransfer failing with aggregator slippage abort** (`err_amount_out_slippage_check_failed`): the FE passes display reward amounts where SUI rewards are folded into stSUI, so swaps were quoted for more stSUI than is actually claimed. Quotes and USD values now use the on-chain claimable estimates from `getClaimRewardInput`, with caller-passed `rewardAmounts` as fallback. Also excludes the BOLT provider from swap routes — its oracle prices expire after 60s and stale prices abort the whole claim tx.
- **claimAndSupplyOrRepay returning converted stSUI to the wallet**: stSUI minted from SUI rewards had no caller-provided supply market (FE only passes borrowed coin types), so it was transferred instead of supplied. It now defaults to the stSUI market, mirroring `collect_reward_and_deposit`'s on-chain auto-deposit.

Verified via mainnet dry runs on affected addresses (10/10 pass with FE-style params, previously 0/3) and the full test suite (57/57).