### PR TITLE
chore: upgrade @mysten/sui to 2.22.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "tslib": "^2.8.1"
       },
       "devDependencies": {
-        "@mysten/sui": "^2.17.0",
+        "@mysten/sui": "2.22.0",
         "@types/jest": "^30.0.0",
         "@types/node": "^24.4.0",
         "babel-loader": "^10.0.0",
@@ -37,13 +37,13 @@
         "node": ">=22.14.0"
       },
       "peerDependencies": {
-        "@mysten/sui": "^2.17.0"
+        "@mysten/sui": "^2.22.0"
       }
     },
     "node_modules/@0no-co/graphql.web": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@0no-co/graphql.web/-/graphql.web-1.2.0.tgz",
-      "integrity": "sha512-/1iHy9TTr63gE1YcR5idjx8UREz1s0kFhydf3bBLCXyqjhkIc6igAzTOx3zPifCwFR87tsh/4Pa9cNts6d2otw==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@0no-co/graphql.web/-/graphql.web-1.3.2.tgz",
+      "integrity": "sha512-Q1+pRlLhE31GOY/2c9BAEnFTNxO7Awtc6fhhEDlxyCBQ2N0IhD32cPVvPChrK9mwBNSgRdW/sF1kd2e0ojHj1Q==",
       "license": "MIT",
       "peerDependencies": {
         "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0"
@@ -55,12 +55,12 @@
       }
     },
     "node_modules/@0no-co/graphqlsp": {
-      "version": "1.15.4",
-      "resolved": "https://registry.npmjs.org/@0no-co/graphqlsp/-/graphqlsp-1.15.4.tgz",
-      "integrity": "sha512-Nt1DVHcZ08lKRKwhiU0amXH77fSdrO6DzyjLE0DkCxfbM/N1SAs32d76y1xtCzM5H9eT0iDS7SdksgRXWJu05g==",
+      "version": "1.17.3",
+      "resolved": "https://registry.npmjs.org/@0no-co/graphqlsp/-/graphqlsp-1.17.3.tgz",
+      "integrity": "sha512-4PPvxDPmbntddpgMyA3VId5/E9YGdRuuS/mW+THOvtTx/C79Pf+lN28LkNNACJrF9L7YACiAJelyOkC6LqUzvw==",
       "license": "MIT",
       "dependencies": {
-        "@gql.tada/internal": "^1.0.0",
+        "@gql.tada/internal": "^1.2.0",
         "graphql": "^15.5.0 || ^16.0.0 || ^17.0.0"
       },
       "peerDependencies": {
@@ -876,21 +876,21 @@
       }
     },
     "node_modules/@gql.tada/cli-utils": {
-      "version": "1.7.3",
-      "resolved": "https://registry.npmjs.org/@gql.tada/cli-utils/-/cli-utils-1.7.3.tgz",
-      "integrity": "sha512-3iQY5E/jvv3Lnh6D1Mh7zr+Bb9C/TGk1DHkm+lbIjQBnZAu2m+BcTcr1e3spUt6Aa6HG/xAN2XxpbWw9oZALEg==",
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/@gql.tada/cli-utils/-/cli-utils-1.9.2.tgz",
+      "integrity": "sha512-cVNs4v8ewLRYJfyAsaHbiAmd5Hm+zXEMvMhBksH58ZU87d6f8crsp2CQG6QtIqnJJw1q0CBWfWTZepGWNcL3QA==",
       "license": "MIT",
       "dependencies": {
-        "@0no-co/graphqlsp": "^1.12.13",
-        "@gql.tada/internal": "1.0.9",
+        "@0no-co/graphqlsp": "^1.17.3",
+        "@gql.tada/internal": "1.2.1",
         "graphql": "^15.5.0 || ^16.0.0 || ^17.0.0"
       },
       "peerDependencies": {
-        "@0no-co/graphqlsp": "^1.12.13",
-        "@gql.tada/svelte-support": "1.0.2",
-        "@gql.tada/vue-support": "1.0.2",
+        "@0no-co/graphqlsp": "^1.16.0",
+        "@gql.tada/svelte-support": "1.0.3",
+        "@gql.tada/vue-support": "1.0.3",
         "graphql": "^15.5.0 || ^16.0.0 || ^17.0.0",
-        "typescript": "^5.0.0 || ^6.0.0"
+        "typescript": "^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
       },
       "peerDependenciesMeta": {
         "@gql.tada/svelte-support": {
@@ -902,16 +902,16 @@
       }
     },
     "node_modules/@gql.tada/internal": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/@gql.tada/internal/-/internal-1.0.9.tgz",
-      "integrity": "sha512-Bp8yi+kLrzIJ3l5Dfxhz48H4OCH2LCX+pShaPcJgh+oiBt6clrjUKDYNDD3Z78aDQ3+Tyrxe4dd0MfLgpSLPPg==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@gql.tada/internal/-/internal-1.2.1.tgz",
+      "integrity": "sha512-1kPMv9KRpD6mfVwtXK+iy43U/gi4bpr4ganfhPLD0TjxpbuVJm7CtZ9wMFdwy3FjLBFN2QhwscNnL7lRPHg4vg==",
       "license": "MIT",
       "dependencies": {
-        "@0no-co/graphql.web": "^1.0.5"
+        "@0no-co/graphql.web": "^1.3.1"
       },
       "peerDependencies": {
         "graphql": "^15.5.0 || ^16.0.0 || ^17.0.0",
-        "typescript": "^5.0.0 || ^6.0.0"
+        "typescript": "^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
     "node_modules/@graphql-typed-document-node/core": {
@@ -1516,36 +1516,36 @@
       }
     },
     "node_modules/@mysten/bcs": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/@mysten/bcs/-/bcs-2.0.5.tgz",
-      "integrity": "sha512-Dop9Xq36DPLlsmIDQZvUg4uJeBBxIGirgp2OXGaEff+mtLKFBoW2HnE3aSTSSpiMQH9XRhjwtiM16zFJhFqz0Q==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@mysten/bcs/-/bcs-2.1.0.tgz",
+      "integrity": "sha512-rIR/cDAqDfBDxmYEZXppN/on8gmh1OW0dYi/Bk2kMBZcYMTaBaEtEX1VR6g7HicVxuMbFAIP0/SQkdH7J9Y5dQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@mysten/utils": "^0.3.3",
-        "@scure/base": "^2.0.0"
+        "@mysten/utils": "^0.4.0",
+        "@scure/base": "^2.2.0"
       }
     },
     "node_modules/@mysten/sui": {
-      "version": "2.17.0",
-      "resolved": "https://registry.npmjs.org/@mysten/sui/-/sui-2.17.0.tgz",
-      "integrity": "sha512-TrS1BCPm4V6rC69MBejmcqnKIyJ5t1iksax4XA9jWarZxAAp9LMmdxEBebejyDT/yAJxYIf3fNm5WBkHE2qnIw==",
+      "version": "2.22.0",
+      "resolved": "https://registry.npmjs.org/@mysten/sui/-/sui-2.22.0.tgz",
+      "integrity": "sha512-M1iQM7C2NZuSafNF0SRaZtA+m7ggg6NUl3hg/2FAcl+NtL7qz8RoK7SO6NmgPmojH2trUJIex4TAnyItO45p2A==",
       "license": "Apache-2.0",
       "dependencies": {
         "@graphql-typed-document-node/core": "^3.2.0",
-        "@mysten/bcs": "^2.0.5",
-        "@mysten/utils": "^0.3.3",
-        "@noble/curves": "^2.0.1",
-        "@noble/hashes": "^2.0.1",
+        "@mysten/bcs": "^2.1.0",
+        "@mysten/utils": "^0.4.0",
+        "@noble/curves": "^2.2.0",
+        "@noble/hashes": "^2.2.0",
         "@protobuf-ts/grpcweb-transport": "^2.11.1",
         "@protobuf-ts/runtime": "^2.11.1",
         "@protobuf-ts/runtime-rpc": "^2.11.1",
-        "@scure/base": "^2.0.0",
-        "@scure/bip32": "^2.0.1",
-        "@scure/bip39": "^2.0.1",
-        "gql.tada": "^1.9.0",
-        "graphql": "^16.12.0",
+        "@scure/base": "^2.2.0",
+        "@scure/bip32": "^2.2.0",
+        "@scure/bip39": "^2.2.0",
+        "gql.tada": "^1.10.1",
+        "graphql": "^16.14.2",
         "poseidon-lite": "0.2.1",
-        "valibot": "^1.2.0"
+        "valibot": "^1.4.1"
       },
       "engines": {
         "node": ">=22"
@@ -1655,12 +1655,12 @@
       }
     },
     "node_modules/@mysten/utils": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/@mysten/utils/-/utils-0.3.3.tgz",
-      "integrity": "sha512-gVHn5toh24eXXLEyBknwwM2F/tbDgqPX0yj77KtHjuoYUallcQ9vSwGfGsAy39IcTB259Yprt/ZOEwdup+zrpA==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@mysten/utils/-/utils-0.4.0.tgz",
+      "integrity": "sha512-nHlXECBl9kE+AHF/aw5a7JVNizae8Kb71A4H18BV/sXd5/l2BaWNGWVatq05fzJo3hF78AWorDxa++1TgcBKWw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@scure/base": "^2.0.0"
+        "@scure/base": "^2.2.0"
       }
     },
     "node_modules/@napi-rs/wasm-runtime": {
@@ -5549,22 +5549,22 @@
       }
     },
     "node_modules/gql.tada": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/gql.tada/-/gql.tada-1.9.2.tgz",
-      "integrity": "sha512-QxRHVpxtrOVdYXz6oavq0lBM+Zdp0swapLGJcD4SLpXDcsD337BHDFrzqqjfkbepv0sSAiO0LGabu1kI5D5Gyg==",
+      "version": "1.11.2",
+      "resolved": "https://registry.npmjs.org/gql.tada/-/gql.tada-1.11.2.tgz",
+      "integrity": "sha512-oBr7ShA5/TmcwOO7BZgN1SynX2rBU+/ltysB0zXc+NCBF+9YOg6MRzJcTfLjIqDKdcE3LGxpOl0l9hBbxmyzmA==",
       "license": "MIT",
       "dependencies": {
-        "@0no-co/graphql.web": "^1.0.5",
-        "@0no-co/graphqlsp": "^1.12.13",
-        "@gql.tada/cli-utils": "1.7.3",
-        "@gql.tada/internal": "1.0.9"
+        "@0no-co/graphql.web": "^1.3.2",
+        "@0no-co/graphqlsp": "^1.17.3",
+        "@gql.tada/cli-utils": "1.9.2",
+        "@gql.tada/internal": "1.2.1"
       },
       "bin": {
         "gql-tada": "bin/cli.js",
         "gql.tada": "bin/cli.js"
       },
       "peerDependencies": {
-        "typescript": "^5.0.0 || ^6.0.0"
+        "typescript": "^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
     "node_modules/graceful-fs": {
@@ -5575,9 +5575,9 @@
       "license": "ISC"
     },
     "node_modules/graphql": {
-      "version": "16.14.1",
-      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.14.1.tgz",
-      "integrity": "sha512-cQOsSMS/IrDz82PVyRDvf/Q1F/bRbBVjJlh+xYOkI1qw2bWRvWGiWc+m2O0d6l4Bt1fyY+8kzJ8JFWGJqNeDBg==",
+      "version": "16.14.2",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.14.2.tgz",
+      "integrity": "sha512-Chq1s4CY7jmh8gO2qvLIJyfCDIN+EHLFW/9iShnp1z8FjBQMoodWP1kDC36VAMXXIvAjj4ARa7ntfAV2BrjsbA==",
       "license": "MIT",
       "engines": {
         "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "tslib": "^2.8.1"
   },
   "devDependencies": {
-    "@mysten/sui": "^2.17.0",
+    "@mysten/sui": "2.22.0",
     "@types/jest": "^30.0.0",
     "@types/node": "^24.4.0",
     "babel-loader": "^10.0.0",
@@ -58,9 +58,9 @@
     "typescript-eslint": "^8.14.0"
   },
   "peerDependencies": {
-    "@mysten/sui": "^2.17.0"
+    "@mysten/sui": "^2.22.0"
   },
   "overrides": {
-    "@mysten/sui": "^2.17.0"
+    "@mysten/sui": "2.22.0"
   }
 }


### PR DESCRIPTION
Pins `@mysten/sui` to exactly `2.22.0`.

Part of aligning the version across all FE-bundled packages (`alphafi-fe`, `alphafi-sdk-js`, `alphalend-sdk-js`, `stsui-sdk`) so the alphafi-fe Docker build stops failing with duplicate-copy `Transaction` type errors caused by `@mysten/sui` version drift between the packages.
