### PR TITLE
chore: point mainnet Pyth JSON-RPC default at Triton endpoint

### DIFF
--- a/src/core/client.ts
+++ b/src/core/client.ts
@@ -126,7 +126,7 @@ export class AlphalendClient {
     // uses JSON-RPC). All other reads go through Blockchain (GraphQL).
     const pythFullnodeUrl =
       network === "mainnet"
-        ? "https://fullnode.mainnet.sui.io/"
+        ? "https://alphalen-suimain-ef6f.mainnet.sui.rpcpool.com/"
         : network === "testnet"
           ? "https://fullnode.testnet.sui.io/"
           : "https://fullnode.devnet.sui.io/";


### PR DESCRIPTION
Mysten shuts off JSON-RPC on fullnode.mainnet.sui.io on 2026-07-26. The internal Pyth SuiJsonRpcClient for mainnet now uses the Triton endpoint. Testnet/devnet defaults are unchanged.

Note: the Triton endpoint is Origin-gated (403 without an allowed browser Origin), so this works from allowed alphafi/alphalend domains; server-side consumers (e.g. the liquidator) hit 403 on the Pyth path since this URL is not configurable.